### PR TITLE
ci/doc-deployment - FIX:  release_docs dependency installation

### DIFF
--- a/.github/workflows/release_docs.yml
+++ b/.github/workflows/release_docs.yml
@@ -13,8 +13,8 @@ jobs:
           fetch-depth: 1
       - name: Install dependencies
         run: |
-          apt-get update -y
-          apt-get install -y doxygen
+          sudo apt-get update -y
+          sudo apt-get install -y doxygen
       - name: Generate docs
         run: doxygen Doxyfile
       - name: Upload artifact


### PR DESCRIPTION
Pull request overview
---------------------
Fix actions failures in `Install dependencies` step due to inappropriate permissions. Invoke `sudo` on update and doxygen install.