### PR TITLE
Add additional latex dependencies for bibliography

### DIFF
--- a/.github/workflows/release_docs.yml
+++ b/.github/workflows/release_docs.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y doxygen
+          sudo apt-get install -y doxygen \
+            texlive-binaries texlive-base
       - name: Generate docs
         run: doxygen Doxyfile
       - name: Upload artifact


### PR DESCRIPTION
This pull request updates the documentation generation workflow to ensure all required dependencies for building docs are installed.

Dependency installation:

* Updated the `Install dependencies` step in `.github/workflows/release_docs.yml` to include `texlive-binaries` and `texlive-base` alongside `doxygen`, ensuring LaTeX-related features in the documentation can be properly generated.