### PR TITLE
Rename SurfaceFactor struct to WallType and update bindings

### DIFF
--- a/EMSCRIPTEN_BINDINGS_CHANGES.md
+++ b/EMSCRIPTEN_BINDINGS_CHANGES.md
@@ -1,33 +1,11 @@
 # Emscripten Bindings Changes
 
-The following table summarizes the changes made to the Emscripten bindings in the MEASUR Tools Suite. These changes are part of an ongoing effort to improve the usability and maintainability of the codebase.
+The following summarizes the changes made to the Emscripten bindings in the MEASUR Tools Suite. These changes are part of an ongoing effort to improve the usability and maintainability of the codebase.
 
 ## Wall Heat Loss Calculator
 
-The `WallLosses` class has been refactored into a namespace called `wall_heat_loss` with many methoids being removed or renamed. The following table outlines the updated emscripten bindings:
-
-| Current Signature                | Previous Signature | Notes                                                                 |
-| -------------------------------- | ------------------ | --------------------------------------------------------------------- |
-| totalHeatLoss                    | getHeatLoss        | Renamed                                                               |
-| convectiveHeatLoss               | ---                | New standalone method to calculate convective heat loss.              |
-| radiativeHeatLoss                | ---                | New standalone method to calculate radiative heat loss.               |
-| ShapeFactor                      | ---                | New Struct that holds shape factor data (description & factor value). |
-| ShapeFactor.surfaceConfiguration | surfaceDescription | New field in ShapeFactor struct that holds the description.           |
-| ShapeFactor.value                | shapeFactor        | New field in ShapeFactor struct that holds the factor value.          |
-| shapeFactors                     | ---                | New method that returns a vector of ShapeFactor structs.              |
-
-See `wasm_wall_heat_loss.test.js` for usage examples.
+The `WallLosses` class has been removed and its functionality has been integrated into the `wall_heat_loss` namespace. See `wasm_wall_heat_loss.test.js` for usage examples.
 
 ## Atmosphere Heat Loss Calculator
 
-The `Atmosphere` class has been removed and its functionality has been integrated into the `atmosphere_heat_loss` namespace. The following table outlines the updated emscripten bindings:
-
-| Current Signature                | Previous Signature | Notes                                                                               |
-| -------------------------------- | ------------------ | ----------------------------------------------------------------------------------- |
-| atmosphereTotalHeatLoss          | getTotalHeatLoss   | Renamed                                                                             |
-| AtmosphereGasType                | ---                | New Struct that holds atmosphere gas type data (description & specific heat value). |
-| AtmosphereGasType.gasDescription | getSubstance       | New field in AtmosphereGasType struct that holds the description of the gas.        |
-| AtmosphereGasType.specificHeat   | getSpecificHeat    | New field in AtmosphereGasType struct that holds the specific heat of the gas       |
-| atmosphereGasTypes               | ---                | New method that returns a vector of AtmosphereGasType structs.                      |
-
-See `wasm_atmosphere_heat_loss.test.js` for usage examples.
+The `Atmosphere` class has been removed and its functionality has been integrated into the `atmosphere_heat_loss` namespace. See `wasm_atmosphere_heat_loss.test.js` for usage examples.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Update (08/25/2025)
 
-The MEASUR Tools Suite is currently undergoing a major update to improve usability and maintainability. This includes a refactoring of the codebase to follow consistent practices, better organization, and enhanced documentation around the engineering aspects of the calculations. To follow the progress of this update, please refer to the [Roadmap](ROADMAP.md). As the codebase is refactored, some Emscripten bindings will change. A summary of these changes can be found in the [Emscripten Bindings Changes](EMSCRIPTEN_BINDINGS_CHANGES.md) document.
+The MEASUR Tools Suite is currently undergoing a major update to improve usability and maintainability. This includes a refactoring of the codebase to follow consistent practices, better organization, and enhanced documentation around the engineering aspects of the calculations. To follow the progress of this update, please refer to the [Roadmap](ROADMAP.md).
 
 ## About
 

--- a/bindings-wasm/processHeat/losses/losses.cpp
+++ b/bindings-wasm/processHeat/losses/losses.cpp
@@ -267,16 +267,18 @@ EMSCRIPTEN_BINDINGS(solidLoadChargeMaterial) {
 
 // Bindings for the wall_heat_loss namespace
 EMSCRIPTEN_BINDINGS(wall_heat_loss) {
-    value_object<wall_heat_loss::ShapeFactor>("WallShapeFactor")
-        .field("surfaceConfiguration", &wall_heat_loss::ShapeFactor::surface_configuration)
-        .field("value", &wall_heat_loss::ShapeFactor::value);
+    using namespace wall_heat_loss;
 
-    register_vector<wall_heat_loss::ShapeFactor>("WallShapeFactorsVector");
+    value_object<WallType>("WallType")
+        .field("wallDescription", &WallType::wall_description)
+        .field("shapeFactor", &WallType::shape_factor);
 
-    function("wallShapeFactors", &wall_heat_loss::shapeFactors);
-    function("wallTotalHeatLoss", &wall_heat_loss::totalHeatLoss);
-    function("wallConvectiveHeatLoss", &wall_heat_loss::convectiveHeatLoss);
-    function("wallRadiativeHeatLoss", &wall_heat_loss::radiativeHeatLoss);
+    register_vector<WallType>("WallTypes");
+
+    function("wallTypes", &wallTypes);
+    function("wallTotalHeatLoss", &totalHeatLoss);
+    function("wallConvectiveHeatLoss", &convectiveHeatLoss);
+    function("wallRadiativeHeatLoss", &radiativeHeatLoss);
 }
 
 // waterCoolingLosses

--- a/docs/calculators/atmosphere_heat_loss_calculator.dox
+++ b/docs/calculators/atmosphere_heat_loss_calculator.dox
@@ -2,9 +2,11 @@
  * @defgroup atmosphere_heat_loss_calculator Atmosphere Heat Loss Calculator
  * @ingroup heat_loss_calculators
  * @brief Calculates heat losses from escaping atmospheric gases in industrial settings.
- * @details The Atmosphere Heat Loss Calculator is used to estimate heat losses from escaping atmospheric gases in
- * industrial settings. The calculator computes the total heat loss based on the flow rate, specific heat of the gas,
- * inlet and outlet temperatures, and a correction factor. Relevant formulas and values are documented below.
+ * @details The Atmosphere Heat Loss Calculator is used to estimate heat losses of process heating equipment due to
+ * the introduction of atmospheric gases (e.g., nitrogen, hydrogen, etc.). These gases absorb heat from the equipment
+ * and carry it away when they exit the system. The calculator computes the total heat loss based on the flow rate,
+ * specific heat of the gas, inlet and outlet temperatures, and a correction factor @cite trinks2003industrial. Relevant
+ * formulas and values are documented below.
  *
  * @heading{Total Heat Loss}
  * @copydoc atmosphere_total_heat_loss_formula
@@ -32,7 +34,7 @@
 /**
  * @defgroup specific_heat_values Specific Heat Values
  * @ingroup atmosphere_heat_loss_calculator
- * @details Reference temperature: @qty{60; \degreeFahrenheit}
+ * Reference temperature: @qty{60; \degreeFahrenheit}
  * | Gas Type        | Specific Heat @unitb{\btu\per\standardCubicFeet\degreeFahrenheit} |
  * | --------------- | ----------------------------------------------------------------- |
  * | Nitrogen        | 0.0185                                                            |
@@ -41,5 +43,4 @@
  * | Endothermic Gas | 0.0185                                                            |
  * | Air             | 0.0184                                                            |
  * | Water Vapor     | 0.0212                                                            |
- * Source: @cite TODO
  */

--- a/docs/calculators/wall_heat_loss_calculator.dox
+++ b/docs/calculators/wall_heat_loss_calculator.dox
@@ -1,10 +1,13 @@
 /**
  * @defgroup wall_heat_loss_calculator Wall Heat Loss Calculator
  * @ingroup heat_loss_calculators
- * @brief Calculates heat losses from walls in industrial settings.
- * @details The Wall Heat Loss Calculator is used to estimate heat losses from walls in industrial settings. The
- * calculator computes the total heat loss as the sum of convective and radiative heat losses, adjusted by a correction
- * factor. Relevant formulas and factors are documented below.
+ * @brief Calculates heat losses from walls of process heating equipment to the ambient.
+ * @details The Wall Heat Loss Calculator is used to estimate the heat losses that occur due to heat transferred from
+ * the outer surface of the walls or casing of process heating equipment to the surrounding. These losses are in the
+ * form of convective heat transfer and radiative heat transfer from the outer wall surfaces. Wall heat losses are high
+ * for systems that are poorly insulated and/or use poorly designed materials. The calculator computes the total heat
+ * loss as the sum of convective and radiative heat losses, adjusted by a correction factor. Relevant formulas and
+ * factors are documented below.
  *
  * @heading{Total Heat Loss}
  * @copydoc wall_total_heat_loss_formula
@@ -30,7 +33,9 @@
  * @symrow{Q_\text{rad}; Radiative heat loss; \btu\per\hour}
  * @symrow{f_\text{corr}; Correction factor; \unitless}
  * @endsymtable
- *
+ */
+
+/**
  * @defgroup wall_convective_heat_loss_formula Wall Convective Heat Loss Formula
  * @ingroup wall_heat_loss_calculator
  * @formula{wall-qconv; Q_\text{conv} = h A \Delta T}
@@ -60,7 +65,9 @@
  * @symrow{T_s; Surface temperature; \degreeFahrenheit}
  * @symrow{T_a; Ambient temperature; \degreeFahrenheit}
  * @endsymtable
- *
+ */
+
+/**
  * @defgroup wall_radiative_heat_loss_formula Wall Radiative Heat Loss Formula
  * @ingroup wall_heat_loss_calculator
  * @formula{wall-qrad; Q_\text{rad} = \varepsilon \sigma A (T_s^4 - T_a^4)}
@@ -74,17 +81,19 @@
  * @symrow{T_s; Surface temperature; \degreeRankine}
  * @symrow{T_a; Ambient temperature; \degreeRankine}
  * @endsymtable
- *
+ */
+
+/**
  * @defgroup shape_factors Shape Factors
  * @ingroup wall_heat_loss_calculator
- * | Surface Configuration                         | Value @unitb{\unitless} |
- * |-----------------------------------------------|-------------------------|
- * | Horizontal cylinders                          | 1.016                   |
- * | Longer vertical cylinders                     | 1.235                   |
- * | Vertical plates                               | 1.394                   |
- * | Horizontal plate facing up, warmer than air   | 1.79                    |
- * | Horizontal plate facing down, warmer than air | 0.89                    |
- * | Horizontal plate facing up, cooler than air   | 0.89                    |
- * | Horizontal plate facing down, cooler than air | 1.79                    |
+ * | Wall Type                                     | Shape Factor @unitb{\unitless} |
+ * |-----------------------------------------------|--------------------------------|
+ * | Horizontal cylinders                          | 1.016                          |
+ * | Longer vertical cylinders                     | 1.235                          |
+ * | Vertical plates                               | 1.394                          |
+ * | Horizontal plate facing up, warmer than air   | 1.79                           |
+ * | Horizontal plate facing down, warmer than air | 0.89                           |
+ * | Horizontal plate facing up, cooler than air   | 0.89                           |
+ * | Horizontal plate facing down, cooler than air | 1.79                           |
  * Source: @cite astmC680
  */

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -17,3 +17,11 @@
   year={2007},
   publisher={Taylor \& Francis}
 }
+
+@book{trinks2003industrial,
+  title={Industrial furnaces},
+  author={Trinks, Willibald and Mawhinney, Matthew Holmes and Shannon, RA and Reed, RJ and Garvey, JR},
+  volume={1},
+  year={2003},
+  publisher={John Wiley \& Sons}
+}

--- a/include/processHeat/losses/atmosphere_heat_loss.h
+++ b/include/processHeat/losses/atmosphere_heat_loss.h
@@ -1,8 +1,9 @@
 #pragma once
 /**
- * @ingroup heat_loss_calculators
+ * @ingroup atmosphere_heat_loss_calculator
  * @file atmosphere_heat_loss.h
  * @authors Gina Accawi, Liam White
+ *
  * @copybrief atmosphere_heat_loss
  */
 
@@ -13,8 +14,7 @@
 /**
  * @ingroup atmosphere_heat_loss_calculator
  * @namespace atmosphere_heat_loss
- * @brief Collection of functions and data structures for calculating heat losses from escaping atmospheric gases in
- * industrial settings.
+ * @copybrief atmosphere_heat_loss_calculator
  */
 namespace atmosphere_heat_loss {
 
@@ -59,14 +59,16 @@ inline const std::vector<GasType>& gasTypes() {
 
 /**
  * @ingroup atmosphere_heat_loss_calculator
- * @brief Calculates the total heat loss from an escaping atmospheric gas.
+ * @brief Calculates the total heat loss from escaping atmospheric gas.
  * @param[in] flow_rate Flow rate of gas @unitb{\standardCubicFeet\per\hour}
  * @param[in] specific_heat Specific heat of gas @unitb{\btu\per\standardCubicFeet\degreeFahrenheit}
  * @param[in] inlet_temperature %Inlet temperature of gas @unitb{\degreeFahrenheit}
  * @param[in] outlet_temperature Outlet temperature of gas @unitb{\degreeFahrenheit}
  * @param[in] correction_factor Correction factor @unitb{\unitless}
  * @return Total heat loss @unitb{\btu\per\hour}
- * @see atmosphere_total_heat_loss_formula, specific_heat_values
+ * @see
+ * - atmosphere_total_heat_loss_formula
+ * - specific_heat_values
  */
 double totalHeatLoss(double flow_rate, double specific_heat, double inlet_temperature, double outlet_temperature,
                      double correction_factor);

--- a/include/processHeat/losses/wall_heat_loss.h
+++ b/include/processHeat/losses/wall_heat_loss.h
@@ -6,6 +6,7 @@
  * @brief Defines functions and data structures for calculating heat losses from walls.
  */
 
+#include <array>
 #include <string>
 #include <vector>
 
@@ -18,35 +19,38 @@ namespace wall_heat_loss {
 
 /**
  * @ingroup wall_heat_loss_calculator
- * @struct ShapeFactor
- * @brief Represents a surface configuration and its associated factor value used in heat loss calculations.
+ * @struct WallType
+ * @brief Represents a wall type and its associated shape factor used in heat loss calculations.
  * @see shape_factors
  */
-struct ShapeFactor {
-    std::string surface_configuration; ///< Description of the surface shape/orientation/condition.
-    double      value;                 ///< Factor value associated with the surface configuration.
+struct WallType {
+    std::string wall_description; ///< Description of the wall type.
+    double      shape_factor;     ///< Shape factor associated with the wall type @unitb{\unitless}
 };
 
 /**
  * @ingroup wall_heat_loss_calculator
- * @brief A collection of shape factors used in wall heat loss calculations.
+ * @brief Predefined shape factors for various wall types.
  * @see shape_factors
  */
-const std::vector<ShapeFactor> kShapeFactors {{"Horizontal cylinders", 1.016},
-                                              {"Longer vertical cylinders", 1.235},
-                                              {"Vertical plates", 1.394},
-                                              {"Horizontal plate facing up, warmer than air", 1.79},
-                                              {"Horizontal plate facing down, warmer than air", 0.89},
-                                              {"Horizontal plate facing up, cooler than air", 0.89},
-                                              {"Horizontal plate facing down, cooler than air", 1.79}};
+inline const std::array<WallType, 7> kWallTypes {{{"Horizontal cylinders", 1.016},
+                                                  {"Longer vertical cylinders", 1.235},
+                                                  {"Vertical plates", 1.394},
+                                                  {"Horizontal plate facing up, warmer than air", 1.79},
+                                                  {"Horizontal plate facing down, warmer than air", 0.89},
+                                                  {"Horizontal plate facing up, cooler than air", 0.89},
+                                                  {"Horizontal plate facing down, cooler than air", 1.79}}};
 
 /**
  * @ingroup wall_heat_loss_calculator
- * @brief Returns the predefined shape factors for wall heat loss calculations.
- * @return A vector of ShapeFactor structs containing surface configurations and their associated factor values.
+ * @brief Retrieves the predefined shape factors for various wall types.
+ * @return A vector of WallType structures containing wall descriptions and their corresponding shape factors.
  * @see shape_factors
  */
-inline const std::vector<ShapeFactor>& shapeFactors() { return kShapeFactors; }
+inline const std::vector<WallType>& wallTypes() {
+    static const std::vector<WallType> wall_types_vector(kWallTypes.begin(), kWallTypes.end());
+    return wall_types_vector;
+}
 
 /**
  * @ingroup wall_heat_loss_calculator

--- a/include/processHeat/losses/wall_heat_loss.h
+++ b/include/processHeat/losses/wall_heat_loss.h
@@ -1,9 +1,10 @@
 #pragma once
 /**
- * @ingroup heat_loss_calculators
+ * @ingroup wall_heat_loss_calculator
  * @file wall_heat_loss.h
  * @authors Gina Accawi, Liam White
- * @brief Defines functions and data structures for calculating heat losses from walls.
+ *
+ * @copybrief wall_heat_loss_calculator
  */
 
 #include <array>
@@ -13,7 +14,7 @@
 /**
  * @ingroup wall_heat_loss_calculator
  * @namespace wall_heat_loss
- * @brief A collection of functions and data structures for calculating heat losses from walls.
+ * @copybrief wall_heat_loss_calculator
  */
 namespace wall_heat_loss {
 
@@ -66,7 +67,11 @@ inline const std::vector<WallType>& wallTypes() {
  * @unitb{\unitless}
  * @param[in] correction_factor Correction factor for the wall heat loss calculations @unitb{\unitless}
  * @return Total heat loss @unitb{\btu\per\hour}.
- * @see wall_total_heat_loss_formula, wall_convective_heat_loss_formula, wall_radiative_heat_loss_formula
+ * @see
+ * - wall_total_heat_loss_formula
+ * - wall_convective_heat_loss_formula
+ * - wall_radiative_heat_loss_formula
+ * - shape_factors
  */
 double totalHeatLoss(double surface_area, double ambient_temperature, double surface_temperature, double wind_speed,
                      double surface_emissivity, double shape_factor, double correction_factor);

--- a/tests/cpp/processHeat/losses/atmosphere_heat_loss.unit.cpp
+++ b/tests/cpp/processHeat/losses/atmosphere_heat_loss.unit.cpp
@@ -2,7 +2,7 @@
 
 #include <catch.hpp>
 
-TEST_CASE("Calculate Total Heat loss for atmospheric gasses", "[Process Heating][Losses][Atmosphere]") {
+TEST_CASE("Calculate total heat loss for atmospheric gasses", "[Process Heating][Losses][Atmosphere]") {
     double flow_rate          = 1200.0; // scfh
     double specific_heat      = 0.02;   // btu/scf°F
     double inlet_temperature  = 100.0;  // °F

--- a/tests/cpp/processHeat/losses/wall_heat_loss.unit.cpp
+++ b/tests/cpp/processHeat/losses/wall_heat_loss.unit.cpp
@@ -2,7 +2,7 @@
 
 #include <catch.hpp>
 
-TEST_CASE("Calculate Heat Loss for furnace walls", "[Heat Loss]") {
+TEST_CASE("Calculate total heat loss for furnace walls", "[Process Heating][Losses][Wall]") {
     double surface_area        = 500.0; // ft²
     double ambient_temperature = 80.0;  // °F
     double surface_temperature = 225.0; // °F

--- a/tests/wasm-mocha/processHeat/losses/wasm_wall_heat_loss.test.js
+++ b/tests/wasm-mocha/processHeat/losses/wasm_wall_heat_loss.test.js
@@ -10,10 +10,10 @@ describe('Process Wall Heat Loss', function () {
         });
     });
 
-    it('should verify defined shape factors are correct', function () {
-        const shapeFactors = moduleInstance.wallShapeFactors();
+    it('should verify defined wall types are correct', function () {
+        const wallTypes = moduleInstance.wallTypes();
 
-        // Expected shape factors
+        // Expected wall types and their shape factors
         const expected = [
             ['Horizontal cylinders', 1.016],
             ['Longer vertical cylinders', 1.235],
@@ -24,13 +24,13 @@ describe('Process Wall Heat Loss', function () {
             ['Horizontal plate facing down, cooler than air', 1.79],
         ];
 
-        // Assert the number of shape factors
-        assert.equal(shapeFactors.size(), expected.length, 'shapeFactors length mismatch');
+        // Assert the number of wall types
+        assert.equal(wallTypes.size(), expected.length, 'wallTypes length mismatch');
 
         // Assert each shape factor's description and value
-        expected.forEach(([desc, factor], i) => {
-            assert.equal(shapeFactors.get(i).surfaceConfiguration, desc, `Configuration description ${i} mismatch`);
-            assert.equal(shapeFactors.get(i).value, factor, `Shape factor ${i} mismatch`);
+        expected.forEach(([description, factor], i) => {
+            assert.equal(wallTypes.get(i).wallDescription, description, `Wall description ${i} mismatch`);
+            assert.equal(wallTypes.get(i).shapeFactor, factor, `Shape factor ${i} mismatch`);
         });
     });
 


### PR DESCRIPTION
This pull request refactors the wall heat loss functionality in the MEASUR Tools Suite to improve clarity and consistency across the codebase and bindings. The main change is the replacement of the `ShapeFactor` struct and related bindings with the new `WallType` struct, updating both C++ and Emscripten interfaces, and ensuring all related documentation and tests reflect the new terminology and structure.

### Refactoring of Wall Heat Loss Data Structures and Bindings

* Replaced the `ShapeFactor` struct with a new `WallType` struct in `wall_heat_loss.h`, updating its fields to `wall_description` and `shape_factor`, and changed the predefined shape factors collection from `kShapeFactors` to `kWallTypes`. The accessor function is now `wallTypes()` instead of `shapeFactors()`.
* Updated Emscripten bindings in `losses.cpp` to reflect the new struct and function names: now binding `WallType`, `wallTypes`, and related functions, instead of `ShapeFactor` and `shapeFactors`.

### Documentation and Test Updates

* Revised the documentation in `EMSCRIPTEN_BINDINGS_CHANGES.md` to describe the removal of the `WallLosses` class and the integration of its functionality into the `wall_heat_loss` namespace, removing detailed signature tables in favor of a summary.
* Updated unit and integration tests in both C++ (`wall_heat_loss.unit.cpp`) and JavaScript (`wasm_wall_heat_loss.test.js`) to use the new `WallType` struct and `wallTypes` accessor, including renaming test cases and assertions to match the new terminology. [[1]](diffhunk://#diff-741ab11eb21b20776a755520b81d87e238a70c569380c0133dec3659f3b41b7dL13-R16) [[2]](diffhunk://#diff-741ab11eb21b20776a755520b81d87e238a70c569380c0133dec3659f3b41b7dL27-R33) [[3]](diffhunk://#diff-ec24f23afe31d559bcebbab0308684b3535399767424e077ccdd7b26561f4014L5-R5)

### Minor Improvements

* Added an `#include <array>` directive to `wall_heat_loss.h` to support the new data structure.
* Minor test case name normalization for atmosphere heat loss tests.
* Removed a redundant sentence from the update section of the main `README.md`.