### PR TITLE
Add GitHub Actions workflow to manage new issues

### DIFF
--- a/.github/workflows/add-new-issue-to-project
+++ b/.github/workflows/add-new-issue-to-project
@@ -1,0 +1,40 @@
+name: Add new Issues to GitHub Project
+
+permissions: 
+  issues: write
+  contents: read
+  
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to project
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          ISSUE_ID=$(gh api graphql -F url="$ISSUE_URL" -f query='
+            query($url: URI!) {
+              resource(url: $url) {
+                ... on Issue {
+                  id
+                }
+              }
+            }
+          ' --jq '.data.resource.id')
+          
+          PROJECT_ID="PVT_kwDOAPjh784BE-oJ"
+          gh api graphql -F issueId="$ISSUE_ID" -F projectId="$PROJECT_ID" -f query='
+            mutation($issueId:ID!, $projectId:ID!) {
+              addProjectV2ItemById(input: {projectId: $projectId, contentId: $issueId}) {
+                item {
+                  id
+                }
+              }
+            }
+          '
+        shell: bash


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow that automatically adds newly opened issues to a specific GitHub Project. This automation streamlines project management by ensuring all new issues are tracked in the designated project.

Automation for issue tracking:

* Added a new workflow file `.github/workflows/add-new-issue-to-project` that triggers on issue creation and uses the GitHub CLI to add the issue to a specified project using GraphQL queries and mutations.