### PR TITLE
feat: add documentation for gas constants

### DIFF
--- a/bindings-wasm/processHeat/losses/losses.cpp
+++ b/bindings-wasm/processHeat/losses/losses.cpp
@@ -135,40 +135,6 @@ EMSCRIPTEN_BINDINGS(gas_flue_gas_material) {
 }
 
 EMSCRIPTEN_BINDINGS(solid_liquid_flue_gas_material) {
-    // // flueGasLossesByMass
-    // // flueGasByMassCalculateHeatingValue
-    // // flueGasByMassCalculateO2
-    // // flueGasByMassCalculateExcessAir
-    // class_<SolidLiquidFlueGasMaterial>("SolidLiquidFlueGasMaterial")
-    //     .constructor<std::string, double, double, double, double, double, double, double>()
-    //     .constructor<double, double, double, double, double, double, double, double, double, double, double, double,
-    //                  double, double, double>()
-    //     .constructor()
-    //     .function("getHeatLoss", &SolidLiquidFlueGasMaterial::getHeatLoss)
-    //     .function("calculateHeatingValueFuel", &SolidLiquidFlueGasMaterial::calculateHeatingValueFuel)
-    //     .function("calculateFlueGasO2", &SolidLiquidFlueGasMaterial::calculateFlueGasO2)
-    //     .function("calculateExcessAirFromFlueGasO2", &SolidLiquidFlueGasMaterial::calculateExcessAirFromFlueGasO2)
-    //     .function("getID", &SolidLiquidFlueGasMaterial::getID)
-    //     .function("getSubstance", &SolidLiquidFlueGasMaterial::getSubstance)
-    //     .function("getCarbon", &SolidLiquidFlueGasMaterial::getCarbon)
-    //     .function("getHydrogen", &SolidLiquidFlueGasMaterial::getHydrogen)
-    //     .function("getSulphur", &SolidLiquidFlueGasMaterial::getSulphur)
-    //     .function("getInertAsh", &SolidLiquidFlueGasMaterial::getInertAsh)
-    //     .function("getO2", &SolidLiquidFlueGasMaterial::getO2)
-    //     .function("getMoisture", &SolidLiquidFlueGasMaterial::getMoisture)
-    //     .function("getNitrogen", &SolidLiquidFlueGasMaterial::getNitrogen)
-    //     .function("setID", &SolidLiquidFlueGasMaterial::setID)
-    //     .function("setSubstance", &SolidLiquidFlueGasMaterial::setSubstance)
-    //     .function("setCarbon", &SolidLiquidFlueGasMaterial::setCarbon)
-    //     .function("setHydrogen", &SolidLiquidFlueGasMaterial::setHydrogen)
-    //     .function("setSulphur", &SolidLiquidFlueGasMaterial::setSulphur)
-    //     .function("setInertAsh", &SolidLiquidFlueGasMaterial::setInertAsh)
-    //     .function("setO2", &SolidLiquidFlueGasMaterial::setO2)
-    //     .function("setMoisture", &SolidLiquidFlueGasMaterial::setMoisture)
-    //     .function("setNitrogen", &SolidLiquidFlueGasMaterial::setNitrogen)
-    //     .function("getAmbientAirTempF", &SolidLiquidFlueGasMaterial::getAmbientAirTempF)
-    //     .function("setAmbientAirTempF", &SolidLiquidFlueGasMaterial::setAmbientAirTempF)
-    //     .function("getHeatingValueFuel", &SolidLiquidFlueGasMaterial::getHeatingValueFuel);
 
     // register_vector<SolidLiquidFlueGasMaterial>("SolidLiquidFlueGasMaterialV");
     using namespace solid_liquid_flue_gas_material;

--- a/docs/dox-content/physics/gas_constants.dox
+++ b/docs/dox-content/physics/gas_constants.dox
@@ -1,0 +1,103 @@
+/**
+ * @defgroup gas_constants Gas Constants
+ * @ingroup physics
+ * @brief Thermodynamic and stoichiometric constants for combustion and flue gas calculations.
+ * @details
+ * This page documents the physical and chemical constants used in combustion, flue gas, and process heat calculations. It includes:
+ *
+ * - **Stoichiometric Ratios:** Conversion factors for elemental combustion (e.g., C to CO2, H to H2O).
+ * - **Molecular and Specific Weights:** Standard values for major gases and fuels.
+ * - **Specific Heat Formulas:** Temperature-dependent Cp equations for key gases and fuels.
+ * - **Combustion Product Yields:** Constants for O2, CO2, H2O, SO2, and heating values per fuel.
+ *
+ * All constants are provided in SI or customary engineering units, with units annotated for clarity. These values are used throughout the MEASUR Tools Suite for energy, mass balance, and flue gas property calculations.
+ *
+ * @heading{Specific Heat Capacity Formulas}
+ * The following temperature-dependent specific heat (Cp) equations are used for major gases (T in \unitb{\degreeFahrenheit}):
+ *
+* @formula{cp-ch4; \text{Methane (CH}_4\text{):}\quad C_p = 4.23 + 0.01177 T}
+* @formula{cp-c2h6; \text{Ethane (C}_2\text{H}_6\text{):}\quad C_p = 4.04 + 0.01636 T}
+* @formula{cp-n2; \text{Nitrogen (N}_2\text{):}\quad C_p = 9.47 - \frac{3470}{T} + \frac{1.07\times10^6}{T^2}}
+* @formula{cp-h2; \text{Hydrogen (H}_2\text{):}\quad C_p = 5.76 + 0.578 \frac{T}{1000} + \frac{20}{\sqrt{T}}}
+* @formula{cp-c3h8; \text{Propane (C}_3\text{H}_8\text{):}\quad C_p = 17.108}
+* @formula{cp-c4h10-cnh2n; \text{Butane/Paraffins (C}_4\text{H}_{10}/\text{C}_n\text{H}_{2n}\text{):}\quad C_p = 22.202}
+* @formula{cp-h2o; \text{Water vapor (H}_2\text{O):}\quad C_p = 19.86 - \frac{597}{\sqrt{T}} + \frac{7500}{T}}
+* @formula{cp-co; \text{Carbon monoxide (CO):}\quad C_p = 9.46 - \frac{3290}{T} + \frac{1.07\times10^6}{T^2}}
+* @formula{cp-co2; \text{Carbon dioxide (CO}_2\text{):}\quad C_p = 16.2 - \frac{6530}{T} + \frac{1.41\times10^6}{T^2}}
+* @formula{cp-so2; \text{Sulphur dioxide (SO}_2\text{):}\quad C_p = 17.472}
+* @formula{cp-o2; \text{Oxygen (O}_2\text{):}\quad C_p = 11.515 - \frac{172}{\sqrt{T}} + \frac{1530}{T}}
+  * @heading{Constant Values Reference}
+ * The following table lists the key constants, their values, and units as used in the MEASUR Tools Suite:
+ *
+* | Constant Name                | Description                                      | Value         | Unit                                 |
+* |------------------------------|--------------------------------------------------|--------------|--------------------------------------|
+* | kCToCO2                      | Mass ratio: C to CO2 produced            | 3.6667       | @unitb{\pound\per\pound}            |
+* | kHToH2O                      | Mass ratio: H to H2O produced            | 9.0          | @unitb{\pound\per\pound}            |
+* | kSToSO2                      | Mass ratio: S to SO2 produced            | 2.0          | @unitb{\pound\per\pound}            |
+* | kCToO2                       | Mass ratio: C to O2 required             | 2.6667       | @unitb{\pound\per\pound}            |
+* | kHToO2                       | Mass ratio: H to O2 required             | 8.0          | @unitb{\pound\per\pound}            |
+* | kSToO2                       | Mass ratio: S to O2 required             | 1.0          | @unitb{\pound\per\pound}            |
+* | kN2O2Ratio                   | N2:O2 ratio in air                       | 3.318        | @unitb{\unitless}                    |
+* | kSO2Cp                       | Specific heat of SO2                     | 17.472       | @unitb{\btu\per\pound\degreeFahrenheit} |
+* | kSO2Mw                       | Molecular weight of SO2                  | 64.06        | @unitb{\pound\per\lbmol}            |
+* | kO2Mw                        | Molecular weight of O2                   | 32.0         | @unitb{\pound\per\lbmol}            |
+* | kN2Mw                        | Molecular weight of N2                   | 28.016       | @unitb{\pound\per\lbmol}            |
+* | kCO2Mw                       | Molecular weight of CO2                  | 44.01        | @unitb{\pound\per\lbmol}            |
+* | kH2OMw                       | Molecular weight of H2O                  | 18.016       | @unitb{\pound\per\lbmol}            |
+* | kMolarVolumeStpL             | Molar volume at STP                      | 22.414       | L/mol                                |
+* | kAirDensityStpKgM3           | Air density at STP                       | 1.205        | kg/m^3                               |
+* | kCh4MolecularWeight          | Methane molecular weight                 | 16.042       | @unitb{\pound\per\lbmol}            |
+* | kCh4SpecificWeight           | Methane specific weight                  | 0.042417     | @unitb{\pound\per\cubicFoot}        |
+* | kCh4O2Generated              | O2 generated per lbmol CH4               | 64           | @unitb{\pound\per\lbmol}            |
+* | kCh4HeatingValue             | Methane higher heating value             | 23875        | @unitb{\btu\per\pound}              |
+* | kCh4HeatingValueVolume       | Methane heating value per volume         | 1012         | @unitb{\btu\per\cubicFoot}          |
+* | kCh4H2oGenerated             | H2O generated per lbmol CH4              | 36.032       | @unitb{\pound\per\lbmol}            |
+* | kCh4Co2Generated             | CO2 generated per lbmol CH4              | 44.01        | @unitb{\pound\per\lbmol}            |
+* | kC2h6MolecularWeight         | Ethane molecular weight                  | 30.068       | @unitb{\pound\per\lbmol}            |
+* | kC2h6SpecificWeight          | Ethane specific weight                   | 0.079503     | @unitb{\pound\per\cubicFoot}        |
+* | kC2h6O2Generated             | O2 generated per lbmol C2H6              | 112          | @unitb{\pound\per\lbmol}            |
+* | kC2h6HeatingValue            | Ethane higher heating value              | 22323        | @unitb{\btu\per\pound}              |
+* | kC2h6HeatingValueVolume      | Ethane heating value per volume          | 1773         | @unitb{\btu\per\cubicFoot}          |
+* | kC2h6H2oGenerated            | H2O generated per lbmol C2H6             | 54.048       | @unitb{\pound\per\lbmol}            |
+* | kC2h6Co2Generated            | CO2 generated per lbmol C2H6             | 88.02        | @unitb{\pound\per\lbmol}            |
+* | kN2MolecularWeight           | Nitrogen molecular weight                | 28.016       | @unitb{\pound\per\lbmol}            |
+* | kN2SpecificWeight            | Nitrogen specific weight                 | 0.074077     | @unitb{\pound\per\cubicFoot}        |
+* | kH2MolecularWeight           | Hydrogen molecular weight                | 2.016        | @unitb{\pound\per\lbmol}            |
+* | kH2SpecificWeight            | Hydrogen specific weight                 | 0.005331     | @unitb{\pound\per\cubicFoot}        |
+* | kH2O2Generated               | O2 generated per lbmol H2                | 16           | @unitb{\pound\per\lbmol}            |
+* | kH2HeatingValue              | Hydrogen higher heating value            | 61095        | @unitb{\btu\per\pound}              |
+* | kH2HeatingValueVolume        | Hydrogen heating value per volume        | 325          | @unitb{\btu\per\cubicFoot}          |
+* | kH2H2oGenerated              | H2O generated per lbmol H2               | 18.016       | @unitb{\pound\per\lbmol}            |
+* | kC3h8MolecularWeight         | Propane molecular weight                 | 44.094       | @unitb{\pound\per\lbmol}            |
+* | kC3h8SpecificWeight          | Propane specific weight                  | 0.116589     | @unitb{\pound\per\cubicFoot}        |
+* | kC3h8O2Generated             | O2 generated per lbmol C3H8              | 160          | @unitb{\pound\per\lbmol}            |
+* | kC3h8HeatingValue            | Propane higher heating value             | 21669        | @unitb{\btu\per\pound}              |
+* | kC3h8HeatingValueVolume      | Propane heating value per volume         | 2523         | @unitb{\btu\per\cubicFoot}          |
+* | kC3h8H2oGenerated            | H2O generated per lbmol C3H8             | 72.064       | @unitb{\pound\per\lbmol}            |
+* | kC3h8Co2Generated            | CO2 generated per lbmol C3H8             | 132.03       | @unitb{\pound\per\lbmol}            |
+* | kC4h10Cnh2nMolecularWeight   | Butane/paraffins molecular weight        | 58.12        | @unitb{\pound\per\lbmol}            |
+* | kC4h10Cnh2nSpecificWeight    | Butane/paraffins specific weight         | 0.153675     | @unitb{\pound\per\cubicFoot}        |
+* | kC4h10Cnh2nO2Generated       | O2 generated per lbmol C4H10/CnH2n       | 208          | @unitb{\pound\per\lbmol}            |
+* | kC4h10Cnh2nHeatingValue      | Butane/paraffins higher heating value    | 21321        | @unitb{\btu\per\pound}              |
+* | kC4h10Cnh2nHeatingValueVolume | Butane/paraffins heating value per volume | 3270        | @unitb{\btu\per\cubicFoot}          |
+* | kC4h10Cnh2nH2oGenerated      | H2O generated per lbmol C4H10/CnH2n      | 90.08        | @unitb{\pound\per\lbmol}            |
+* | kC4h10Cnh2nCo2Generated      | CO2 generated per lbmol C4H10/CnH2n      | 176.04       | @unitb{\pound\per\lbmol}            |
+* | kH2oMolecularWeight          | Water vapor molecular weight             | 18.016       | @unitb{\pound\per\lbmol}            |
+* | kH2oSpecificWeight           | Water vapor specific weight              | 0.047636     | @unitb{\pound\per\cubicFoot}        |
+* | kH2oH2oGenerated             | H2O generated per lbmol H2O              | 18.016       | @unitb{\pound\per\lbmol}            |
+* | kCoMolecularWeight           | Carbon monoxide molecular weight         | 28.01        | @unitb{\pound\per\lbmol}            |
+* | kCoSpecificWeight            | Carbon monoxide specific weight          | 0.074061     | @unitb{\pound\per\cubicFoot}        |
+* | kCoO2Generated               | O2 generated per lbmol CO                | 16           | @unitb{\pound\per\lbmol}            |
+* | kCoHeatingValue              | Carbon monoxide higher heating value     | 4347         | @unitb{\btu\per\pound}              |
+* | kCoHeatingValueVolume        | Carbon monoxide heating value per volume | 321          | @unitb{\btu\per\cubicFoot}          |
+* | kCoCo2Generated              | CO2 generated per lbmol CO               | 44.01        | @unitb{\pound\per\lbmol}            |
+* | kCo2MolecularWeight          | Carbon dioxide molecular weight          | 44.01        | @unitb{\pound\per\lbmol}            |
+* | kCo2SpecificWeight           | Carbon dioxide specific weight           | 0.116367     | @unitb{\pound\per\cubicFoot}        |
+* | kCo2Co2Generated             | CO2 generated per lbmol CO2              | 44.01        | @unitb{\pound\per\lbmol}            |
+* | kSo2MolecularWeight          | Sulphur dioxide molecular weight         | 64.06        | @unitb{\pound\per\lbmol}            |
+* | kSo2SpecificWeight           | Sulphur dioxide specific weight          | 0.169381     | @unitb{\pound\per\cubicFoot}        |
+* | kO2MolecularWeight           | Oxygen molecular weight                  | 32.00        | @unitb{\pound\per\lbmol}            |
+* | kO2SpecificWeight            | Oxygen specific weight                   | 0.084611     | @unitb{\pound\per\cubicFoot}        |
+* | O2_O2_GENERATED              | O2 generated per lbmol O2 | -32          | @unitb{\pound\per\lbmol}            |
+ *
+ */

--- a/include/physics/gas_composition.h
+++ b/include/physics/gas_composition.h
@@ -176,65 +176,65 @@ class GasComposition {
 
   private:
     void setCH4(double composition_percent, double composition_by_volume) {
-        ch4 = GasProperties(specificHeatCH4, CH4_MOLECULAR_WEIGHT, CH4_SPECIFIC_WEIGHT, composition_percent,
-                            composition_by_volume, CH4_O2_GENERATED, CH4_HEATING_VALUE, CH4_HEATING_VALUE_VOLUME,
-                            CH4_H2O_GENERATED, CH4_CO2_GENERATED);
+        ch4 = GasProperties(specificHeatCH4, kCh4MolecularWeight, kCh4SpecificWeight, composition_percent,
+                    composition_by_volume, kCh4O2Generated, kCh4HeatingValue, kCh4HeatingValueVolume,
+                    kCh4H2oGenerated, kCh4Co2Generated);
     }
 
     void setC2H6(double composition_percent, double composition_by_volume) {
-        c2h6 = GasProperties(specificHeatC2H6, C2H6_MOLECULAR_WEIGHT, C2H6_SPECIFIC_WEIGHT, composition_percent,
-                             composition_by_volume, C2H6_O2_GENERATED, C2H6_HEATING_VALUE, C2H6_HEATING_VALUE_VOLUME,
-                             C2H6_H2O_GENERATED, C2H6_CO2_GENERATED);
+        c2h6 = GasProperties(specificHeatC2H6, kC2h6MolecularWeight, kC2h6SpecificWeight, composition_percent,
+                     composition_by_volume, kC2h6O2Generated, kC2h6HeatingValue, kC2h6HeatingValueVolume,
+                     kC2h6H2oGenerated, kC2h6Co2Generated);
     }
 
     void setN2(double composition_percent, double composition_by_volume) {
-        n2 = GasProperties(specificHeatN2, N2_MOLECULAR_WEIGHT, N2_SPECIFIC_WEIGHT, composition_percent,
-                           composition_by_volume, 0, 0, 0, 0, 0);
+        n2 = GasProperties(specificHeatN2, kN2MolecularWeight, kN2SpecificWeight, composition_percent,
+                   composition_by_volume, 0, 0, 0, 0, 0);
     }
 
     void setH2(double composition_percent, double composition_by_volume) {
-        h2 = GasProperties(specificHeatH2, H2_MOLECULAR_WEIGHT, H2_SPECIFIC_WEIGHT, composition_percent,
-                           composition_by_volume, H2_O2_GENERATED, H2_HEATING_VALUE, H2_HEATING_VALUE_VOLUME,
-                           H2_H2O_GENERATED, 0);
+        h2 = GasProperties(specificHeatH2, kH2MolecularWeight, kH2SpecificWeight, composition_percent,
+                   composition_by_volume, kH2O2Generated, kH2HeatingValue, kH2HeatingValueVolume,
+                   kH2H2oGenerated, 0);
     }
 
     void setC3H8(double composition_percent, double composition_by_volume) {
-        c3h8 = GasProperties(specificHeatC3H8, C3H8_MOLECULAR_WEIGHT, C3H8_SPECIFIC_WEIGHT, composition_percent,
-                             composition_by_volume, C3H8_O2_GENERATED, C3H8_HEATING_VALUE, C3H8_HEATING_VALUE_VOLUME,
-                             C3H8_H2O_GENERATED, C3H8_CO2_GENERATED);
+        c3h8 = GasProperties(specificHeatC3H8, kC3h8MolecularWeight, kC3h8SpecificWeight, composition_percent,
+                     composition_by_volume, kC3h8O2Generated, kC3h8HeatingValue, kC3h8HeatingValueVolume,
+                     kC3h8H2oGenerated, kC3h8Co2Generated);
     }
 
     void setC4H10CnH2n(double composition_percent, double composition_by_volume) {
-        c4h10_cnh2n = GasProperties(specificHeatC4H10CnH2n, C4H10_CNH2N_MOLECULAR_WEIGHT, C4H10_CNH2N_SPECIFIC_WEIGHT,
-                                    composition_percent, composition_by_volume, C4H10_CNH2N_O2_GENERATED,
-                                    C4H10_CNH2N_HEATING_VALUE, C4H10_CNH2N_HEATING_VALUE_VOLUME,
-                                    C4H10_CNH2N_H2O_GENERATED, C4H10_CNH2N_CO2_GENERATED);
+        c4h10_cnh2n = GasProperties(specificHeatC4H10CnH2n, kC4h10Cnh2nMolecularWeight, kC4h10Cnh2nSpecificWeight,
+                        composition_percent, composition_by_volume, kC4h10Cnh2nO2Generated,
+                        kC4h10Cnh2nHeatingValue, kC4h10Cnh2nHeatingValueVolume,
+                        kC4h10Cnh2nH2oGenerated, kC4h10Cnh2nCo2Generated);
     }
 
     void setH2O(double composition_percent, double composition_by_volume) {
-        h2o = GasProperties(specificHeatH2O, H2O_MOLECULAR_WEIGHT, H2O_SPECIFIC_WEIGHT, composition_percent,
-                            composition_by_volume, 0, 0, 0, H2O_H2O_GENERATED, 0);
+        h2o = GasProperties(specificHeatH2O, kH2oMolecularWeight, kH2oSpecificWeight, composition_percent,
+                    composition_by_volume, 0, 0, 0, kH2oH2oGenerated, 0);
     }
 
     void setCO(double composition_percent, double composition_by_volume) {
-        co = GasProperties(specificHeatCO, CO_MOLECULAR_WEIGHT, CO_SPECIFIC_WEIGHT, composition_percent,
-                           composition_by_volume, CO_O2_GENERATED, CO_HEATING_VALUE, CO_HEATING_VALUE_VOLUME, 0,
-                           CO_CO2_GENERATED);
+        co = GasProperties(specificHeatCO, kCoMolecularWeight, kCoSpecificWeight, composition_percent,
+                   composition_by_volume, kCoO2Generated, kCoHeatingValue, kCoHeatingValueVolume, 0,
+                   kCoCo2Generated);
     }
 
     void setCO2(double composition_percent, double composition_by_volume) {
-        co2 = GasProperties(specificHeatCO2, CO2_MOLECULAR_WEIGHT, CO2_SPECIFIC_WEIGHT, composition_percent,
-                            composition_by_volume, 0, 0, 0, 0, CO2_CO2_GENERATED);
+        co2 = GasProperties(specificHeatCO2, kCo2MolecularWeight, kCo2SpecificWeight, composition_percent,
+                    composition_by_volume, 0, 0, 0, 0, kCo2Co2Generated);
     }
 
     void setSO2(double composition_percent, double composition_by_volume) {
-        so2 = GasProperties(specificHeatSO2, SO2_MOLECULAR_WEIGHT, SO2_SPECIFIC_WEIGHT, composition_percent,
-                            composition_by_volume, 0, 0, 0, 0, 0);
+        so2 = GasProperties(specificHeatSO2, kSo2MolecularWeight, kSo2SpecificWeight, composition_percent,
+                    composition_by_volume, 0, 0, 0, 0, 0);
     }
 
     void setO2(double composition_percent, double composition_by_volume) {
-        o2 = GasProperties(specificHeatO2, O2_MOLECULAR_WEIGHT, O2_SPECIFIC_WEIGHT, composition_percent,
-                           composition_by_volume, O2_O2_GENERATED, 0, 0, 0, 0);
+        o2 = GasProperties(specificHeatO2, kO2MolecularWeight, kO2SpecificWeight, composition_percent,
+                   composition_by_volume, kO2O2Generated, 0, 0, 0, 0);
     }
 
     void                 setTotalCompositionWeight();

--- a/include/physics/gas_constants.h
+++ b/include/physics/gas_constants.h
@@ -93,80 +93,80 @@ inline double specificHeatSO2(double t) {
 inline double specificHeatO2(double t) { return 11.515 - 172 / std::pow(t, 0.5) + 1530 / t; }
 
 // Methane (CH4)
-constexpr double CH4_MOLECULAR_WEIGHT     = 16.042;
-constexpr double CH4_SPECIFIC_WEIGHT      = 0.042417;
-constexpr double CH4_O2_GENERATED         = 64;
-constexpr double CH4_HEATING_VALUE        = 23875;
-constexpr double CH4_HEATING_VALUE_VOLUME = 1012;
-constexpr double CH4_H2O_GENERATED        = 36.032;
-constexpr double CH4_CO2_GENERATED        = 44.01;
+constexpr double kCh4MolecularWeight     = 16.042;
+constexpr double kCh4SpecificWeight      = 0.042417;
+constexpr double kCh4O2Generated         = 64;
+constexpr double kCh4HeatingValue        = 23875;
+constexpr double kCh4HeatingValueVolume = 1012;
+constexpr double kCh4H2oGenerated        = 36.032;
+constexpr double kCh4Co2Generated        = 44.01;
 
 // Ethane (C2H6)
-constexpr double C2H6_MOLECULAR_WEIGHT     = 30.068;
-constexpr double C2H6_SPECIFIC_WEIGHT      = 0.079503;
-constexpr double C2H6_O2_GENERATED         = 112;
-constexpr double C2H6_HEATING_VALUE        = 22323;
-constexpr double C2H6_HEATING_VALUE_VOLUME = 1773;
-constexpr double C2H6_H2O_GENERATED        = 54.048;
-constexpr double C2H6_CO2_GENERATED        = 88.02;
+constexpr double kC2h6MolecularWeight     = 30.068;
+constexpr double kC2h6SpecificWeight      = 0.079503;
+constexpr double kC2h6O2Generated         = 112;
+constexpr double kC2h6HeatingValue        = 22323;
+constexpr double kC2h6HeatingValueVolume = 1773;
+constexpr double kC2h6H2oGenerated        = 54.048;
+constexpr double kC2h6Co2Generated        = 88.02;
 
 // Nitrogen (N2)
-constexpr double N2_MOLECULAR_WEIGHT = 28.016;
-constexpr double N2_SPECIFIC_WEIGHT  = 0.074077;
+constexpr double kN2MolecularWeight = 28.016;
+constexpr double kN2SpecificWeight  = 0.074077;
 
 // Hydrogen (H2)
-constexpr double H2_MOLECULAR_WEIGHT     = 2.016;
-constexpr double H2_SPECIFIC_WEIGHT      = 0.005331;
-constexpr double H2_O2_GENERATED         = 16;
-constexpr double H2_HEATING_VALUE        = 61095;
-constexpr double H2_HEATING_VALUE_VOLUME = 325;
-constexpr double H2_H2O_GENERATED        = 18.016;
+constexpr double kH2MolecularWeight     = 2.016;
+constexpr double kH2SpecificWeight      = 0.005331;
+constexpr double kH2O2Generated         = 16;
+constexpr double kH2HeatingValue        = 61095;
+constexpr double kH2HeatingValueVolume = 325;
+constexpr double kH2H2oGenerated        = 18.016;
 
 // Propane (C3H8)
-constexpr double C3H8_MOLECULAR_WEIGHT     = 44.094;
-constexpr double C3H8_SPECIFIC_WEIGHT      = 0.116589;
-constexpr double C3H8_O2_GENERATED         = 160;
-constexpr double C3H8_HEATING_VALUE        = 21669;
-constexpr double C3H8_HEATING_VALUE_VOLUME = 2523;
-constexpr double C3H8_H2O_GENERATED        = 72.064;
-constexpr double C3H8_CO2_GENERATED        = 132.03;
+constexpr double kC3h8MolecularWeight     = 44.094;
+constexpr double kC3h8SpecificWeight      = 0.116589;
+constexpr double kC3h8O2Generated         = 160;
+constexpr double kC3h8HeatingValue        = 21669;
+constexpr double kC3h8HeatingValueVolume = 2523;
+constexpr double kC3h8H2oGenerated        = 72.064;
+constexpr double kC3h8Co2Generated        = 132.03;
 
 // Butane/Paraffins (C4H10/CnH2n)
-constexpr double C4H10_CNH2N_MOLECULAR_WEIGHT     = 58.12;
-constexpr double C4H10_CNH2N_SPECIFIC_WEIGHT      = 0.153675;
-constexpr double C4H10_CNH2N_O2_GENERATED         = 208;
-constexpr double C4H10_CNH2N_HEATING_VALUE        = 21321;
-constexpr double C4H10_CNH2N_HEATING_VALUE_VOLUME = 3270;
-constexpr double C4H10_CNH2N_H2O_GENERATED        = 90.08;
-constexpr double C4H10_CNH2N_CO2_GENERATED        = 176.04;
+constexpr double kC4h10Cnh2nMolecularWeight     = 58.12;
+constexpr double kC4h10Cnh2nSpecificWeight      = 0.153675;
+constexpr double kC4h10Cnh2nO2Generated         = 208;
+constexpr double kC4h10Cnh2nHeatingValue        = 21321;
+constexpr double kC4h10Cnh2nHeatingValueVolume = 3270;
+constexpr double kC4h10Cnh2nH2oGenerated        = 90.08;
+constexpr double kC4h10Cnh2nCo2Generated        = 176.04;
 
 // Water vapor (H2O)
-constexpr double H2O_MOLECULAR_WEIGHT = 18.016;
-constexpr double H2O_SPECIFIC_WEIGHT  = 0.047636;
-constexpr double H2O_H2O_GENERATED    = 18.016;
+constexpr double kH2oMolecularWeight = 18.016;
+constexpr double kH2oSpecificWeight  = 0.047636;
+constexpr double kH2oH2oGenerated    = 18.016;
 
 // Carbon monoxide (CO)
-constexpr double CO_MOLECULAR_WEIGHT     = 28.01;
-constexpr double CO_SPECIFIC_WEIGHT      = 0.074061;
-constexpr double CO_O2_GENERATED         = 16;
-constexpr double CO_HEATING_VALUE        = 4347;
-constexpr double CO_HEATING_VALUE_VOLUME = 321;
-constexpr double CO_CO2_GENERATED        = 44.01;
+constexpr double kCoMolecularWeight     = 28.01;
+constexpr double kCoSpecificWeight      = 0.074061;
+constexpr double kCoO2Generated         = 16;
+constexpr double kCoHeatingValue        = 4347;
+constexpr double kCoHeatingValueVolume = 321;
+constexpr double kCoCo2Generated        = 44.01;
 
 // Carbon dioxide (CO2)
-constexpr double CO2_MOLECULAR_WEIGHT = 44.01;
-constexpr double CO2_SPECIFIC_WEIGHT  = 0.116367;
-constexpr double CO2_CO2_GENERATED    = 44.01;
+constexpr double kCo2MolecularWeight = 44.01;
+constexpr double kCo2SpecificWeight  = 0.116367;
+constexpr double kCo2Co2Generated    = 44.01;
 
 // Sulphur dioxide (SO2)
-constexpr double SO2_MOLECULAR_WEIGHT = 64.06;
-constexpr double SO2_SPECIFIC_WEIGHT  = 0.169381;
+constexpr double kSo2MolecularWeight = 64.06;
+constexpr double kSo2SpecificWeight  = 0.169381;
 
 // Oxygen (O2)
-constexpr double O2_MOLECULAR_WEIGHT = 32.00;
-constexpr double O2_SPECIFIC_WEIGHT  = 0.084611;
-constexpr double O2_O2_GENERATED     = -32;
+constexpr double kO2MolecularWeight = 32.00;
+constexpr double kO2SpecificWeight  = 0.084611;
+constexpr double kO2O2Generated     = -32;
 
-constexpr double MOLAR_VOLUME_STP_L    = 22.414; // L/mol
-constexpr double AIR_DENSITY_STP_KG_M3 = 1.205; // kg/m3
+constexpr double kMolarVolumeStpL    = 22.414; // L/mol
+constexpr double kAirDensityStpKgM3 = 1.205; // kg/m3
 }; // namespace gas_constants


### PR DESCRIPTION
connects #57 

This pull request makes several improvements to the way gas constants are defined, documented, and used throughout the codebase. The main changes include standardizing the naming of gas constant variables, updating the usage of these constants in the `GasComposition` class, and adding comprehensive documentation for gas constants and their formulas.

**Refactoring and Standardization of Gas Constants:**

* All gas constant variables in `include/physics/gas_constants.h` have been renamed from all-uppercase (e.g., `CH4_MOLECULAR_WEIGHT`) to a standardized `kCamelCase` format (e.g., `kCh4MolecularWeight`) for improved consistency and clarity.

* The `GasComposition` class in `include/physics/gas_composition.h` has been updated to use the new standardized constant names throughout its setter methods, replacing the old uppercase constants. This ensures consistency and reduces the risk of errors from mismatched variable names.

**Documentation Improvements:**

* A new Doxygen documentation file, `docs/dox-content/physics/gas_constants.dox`, has been added. This file provides detailed descriptions of all thermodynamic and stoichiometric constants, includes tables of values and units, and documents the specific heat equations used for major gases. This will help developers and users understand the purpose and usage of each constant.

**Bindings and API Clean-up:**

* The previously commented-out Emscripten bindings for `SolidLiquidFlueGasMaterial` in `bindings-wasm/processHeat/losses/losses.cpp` have been removed, further cleaning up the codebase.