### PR TITLE
Issue 53: Aux power used changes from review

### DIFF
--- a/docs/dox-content/calculators/processHeat/losses/auxiliary_power_used_calculator.dox
+++ b/docs/dox-content/calculators/processHeat/losses/auxiliary_power_used_calculator.dox
@@ -29,7 +29,7 @@
  * @subheading{Symbols}
  * @symtable
  * @symrow{Q_\text{aux}; Auxiliary power used; \btu\per\hour}
- * @symrow{P; Motor phase; \unitless}
+ * @symrow{P; Number of motor phases; \unitless}
  * @symrow{V; Supply voltage; \volt}
  * @symrow{I; Average current; \ampere}
  * @symrow{PF; Power factor; \unitless}

--- a/include/processHeat/losses/auxiliary_power_used.h
+++ b/include/processHeat/losses/auxiliary_power_used.h
@@ -20,7 +20,7 @@ namespace auxiliary_power_used {
  * @ingroup auxiliary_power_used_calculator
  * @brief Calculates the auxiliary power used by electrical systems associated with process heating equipment.
  * @details This function computes the energy use of motors and other auxiliary systems using electricity, based on electrical parameters and operating time.
- * @param[in] motor_phase Motor phase @unitb{\unitless}
+ * @param[in] number_of_motor_phases Number of motor phases @unitb{\unitless}
  * @param[in] supply_voltage Supply voltage @unitb{\volt}
  * @param[in] avg_current Average current @unitb{\ampere}
  * @param[in] power_factor Power factor @unitb{\unitless}
@@ -28,7 +28,7 @@ namespace auxiliary_power_used {
  * @return Auxiliary power used @unitb{\btu\per\hour}
  * @see auxiliary_power_used_formula
  */
-double calculatePowerUsed(double motor_phase, double supply_voltage, double avg_current, double power_factor, double operating_time);
+double calculatePowerUsed(double number_of_motor_phases, double supply_voltage, double avg_current, double power_factor, double operating_time);
 
 } // namespace auxiliary_power_used
 

--- a/src/processHeat/losses/auxiliary_power_used.cpp
+++ b/src/processHeat/losses/auxiliary_power_used.cpp
@@ -7,12 +7,12 @@
 
 namespace auxiliary_power_used {
 
-double calculatePowerUsed(double motor_phase, double supply_voltage, double avg_current, double power_factor,
+double calculatePowerUsed(double number_of_motor_phases, double supply_voltage, double avg_current, double power_factor,
                     double operating_time) {
               // Convert percent inputs to fractions
               const double ot_frac = operating_time / 100.0;
               // Electrical power in kW
-              const double electrical_kw = std::pow(motor_phase, 0.5) * supply_voltage * avg_current * power_factor * ot_frac / 1000.0;
+              const double electrical_kw = std::pow(number_of_motor_phases, 0.5) * supply_voltage * avg_current * power_factor * ot_frac / 1000.0;
               // Convert kW to BTU/hr using constant
               const double btu_per_hr = electrical_kw * physics::conversions::kKilowattToBtuPerHour;
               return btu_per_hr;


### PR DESCRIPTION
connects #53 

This pull request updates the terminology and variable naming related to motor phases in the auxiliary power calculation code and documentation to improve clarity and consistency. The main change is renaming the parameter and symbol from "motor phase" to "number of motor phases," which better reflects its actual usage in the formula.

**Documentation and API consistency:**

* Updated the symbol description in `docs/dox-content/calculators/processHeat/losses/auxiliary_power_used_calculator.dox` to clarify that `P` represents the number of motor phases, not just "motor phase."
* Renamed the function parameter in `include/processHeat/losses/auxiliary_power_used.h` from `motor_phase` to `number_of_motor_phases` for improved clarity and consistency with the formula and documentation.

**Code implementation:**

* Updated the implementation in `src/processHeat/losses/auxiliary_power_used.cpp` to use the new parameter name `number_of_motor_phases` throughout the function, ensuring consistent usage in both the signature and the calculation logic.