### PR TITLE
Issue 168: exhaust gas dox update from review

### DIFF
--- a/docs/dox-content/calculators/processHeat/losses/energy_input_exhaust_gas_heat_loss_calculator.dox
+++ b/docs/dox-content/calculators/processHeat/losses/energy_input_exhaust_gas_heat_loss_calculator.dox
@@ -21,6 +21,9 @@
  * @heading{Available Heat}
  * @copydoc energy_input_exhaust_gas_available_heat_cpp_formula
  *
+ * @heading{Base Heat}
+ * @copydoc energy_input_exhaust_gas_base_heat_cpp_formula
+ *
  * @heading{Air Correction}
  * @copydoc energy_input_exhaust_gas_air_correction_cpp_formula
  *
@@ -78,18 +81,37 @@
  * @details The available heat represents the fraction of input energy that remains available for useful work 
  * after accounting for exhaust gas temperature, excess air, and combustion air preheat.
  * 
- * @formula{energy-input-exhaust-gas-available-heat-cpp; AH = 95 - 0.025 \cdot T_{exh} + AC + CAC}
+ * @formula{energy-input-exhaust-gas-available-heat-cpp; AH = BH + AC + CAC}
  * 
  * @subheading{Symbols}
  * @symtable
  * @symrow{AH; Available heat percent; \percent}
- * @symrow{95; Base available heat at zero exhaust temperature; \percent}
- * @symrow{0.025; Exhaust temperature loss coefficient; \percent\per\degreeFahrenheit}
- * @symrow{T_{exh}; Exhaust gas temperature; \degreeFahrenheit}
+ * @symrow{BH; Base heat percentage; \percent}
  * @symrow{AC; Air correction; \percent}
  * @symrow{CAC; Combustion air correction; \percent}
  * @endsymtable
  */
+
+
+/**
+ * @defgroup energy_input_exhaust_gas_base_heat_cpp_formula Base Heat Formula
+ * @ingroup energy_input_exhaust_gas_heat_loss_calculator
+ * @brief Base available heat before corrections.
+ * @details The base heat formula calculates the starting percentage of input heat available for useful work, before accounting for losses due to excess air and combustion air preheat. 
+ * It is determined by subtracting the exhaust temperature loss from a model-specific base value (95%). 
+ * This step isolates the effect of exhaust gas temperature on available heat, prior to applying air corrections.
+ *
+ * @formula{energy-input-exhaust-gas-base-heat-cpp; BH = 95 - 0.025 \cdot T_{exh}}
+ *
+ * @subheading{Symbols}
+ * @symtable
+ * @symrow{BH; Base heat percentage; \percent}
+ * @symrow{95; Base available heat at zero exhaust temperature; \percent}
+ * @symrow{0.025; Exhaust temperature loss coefficient; \percent\per\degreeFahrenheit}
+ * @symrow{T_{exh}; Exhaust gas temperature; \degreeFahrenheit}
+ * @endsymtable
+ */
+
 
 /**
  * @defgroup energy_input_exhaust_gas_air_correction_cpp_formula Air Correction Formula


### PR DESCRIPTION
connects #168 

This pull request updates the documentation for the energy input exhaust gas heat loss calculator, clarifying the calculation of available heat by introducing a new "Base Heat" concept and formula. The changes improve the explanation of how available heat is determined by separating the base heat calculation from subsequent corrections.

**Documentation improvements:**

* Added a new section for "Base Heat" with its own heading and formula, clearly explaining how base heat is calculated before corrections are applied.
* Updated the available heat formula to use the new base heat variable (`AH = BH + AC + CAC`), and expanded the symbol table to include `BH`, `AC`, and `CAC` for clarity.
* Provided a detailed explanation and symbol definitions for the base heat formula, making the documentation more comprehensive and easier to understand.