### PR TITLE
fixup: add missing units for documentation

### DIFF
--- a/docs/dependencies/mathjax-config.js
+++ b/docs/dependencies/mathjax-config.js
@@ -48,6 +48,7 @@ window.MathJax = {
         ready() {
             MathJax.startup.defaultReady();
             MathJax.tex2mml(String.raw`
+                \DeclareSIUnit{\poundFuel}{lb_{fuel}}
                 \DeclareSIUnit{\abs}{abs}
                 \DeclareSIUnit{\dollar}{$}
                 \DeclareSIUnit{\britishThermalUnit}{Btu}
@@ -95,6 +96,7 @@ window.MathJax = {
                 \DeclareSIUnit{\lbmol}{lbmol}
                 \DeclareSIUnit{\year}{yr}
                 \DeclareSIUnit{\ton}{ton}
+                \DeclareSIUnit{\inchMercury}{inHg}
             `);
         }
     },

--- a/docs/dox-content/calculators/processHeat/losses/solid_liquid_flue_gas_calculator.dox
+++ b/docs/dox-content/calculators/processHeat/losses/solid_liquid_flue_gas_calculator.dox
@@ -141,8 +141,8 @@
  * in ash, and sensible heat carried away by hot ash.
  *
  * @formula{slfgm-h-moisture; h_{moisture} = X_{moisture} \cdot (T_{fg} - T_{ref})}
-* @formula{slfgm-h-carbon; h_{carbon} = 14093.0 \cdot X_{unburned,carbon} \cdot \left(\frac{X_{ash}}{x_{fuel}}\right)}
-* @formula{slfgm-h-ash; h_{ash} = \left(\frac{X_{ash}}{x_{fuel}}\right) \cdot 0.25 \cdot (1.8 \cdot T_{ash,discharge} + 32.0 - T_{ref})}
+ * @formula{slfgm-h-carbon; h_{carbon} = 14093.0 \cdot X_{unburned,carbon} \cdot (X_{ash}/x_{fuel})}
+ * @formula{slfgm-h-ash; h_{ash} = (X_{ash}/x_{fuel}) \cdot 0.25 \cdot (1.8 \cdot T_{ash,discharge} + 32.0 - T_{ref})}
  *
  * @par Symbols
  * @symtable

--- a/docs/dox-content/calculators/processHeat/losses/solid_liquid_flue_gas_calculator.dox
+++ b/docs/dox-content/calculators/processHeat/losses/solid_liquid_flue_gas_calculator.dox
@@ -90,14 +90,14 @@
  * @par Symbols
  * @symtable
  * @symrow{h_{i}; Sensible heat of constituent i; \btu\per\pound}
- * @symrow{m_{i}; Mass of constituent i; \pound\per\pound\;fuel}
+ * @symrow{m_{i}; Mass of constituent i; \pound\per\poundFuel}
  * @symrow{Cp_{i}; Specific heat of constituent i - see @ref gas_constants; \btu\per\pound\degreeFahrenheit}
  * @symrow{MW_{i}; Molecular weight of constituent i - see @ref gas_constants; \pound\per\lbmol}
  * @symrow{T_{fg}; Flue gas temperature; \degreeFahrenheit}
  * @symrow{T_{ref}; Reference temperature (ambient); \degreeFahrenheit}
  * @symrow{h_{sat}; Enthalpy of saturated steam; \btu\per\pound}
- * @symrow{m_{H_2O,fuel}; Water from fuel moisture and combustion; \pound\per\pound\;fuel}
- * @symrow{m_{H_2O,air}; Water from combustion air moisture; \pound\per\pound\;fuel}
+ * @symrow{m_{H_2O,fuel}; Water from fuel moisture and combustion; \pound\per\poundFuel}
+ * @symrow{m_{H_2O,air}; Water from combustion air moisture; \pound\per\poundFuel}
  * @symrow{h_{fg}; Total sensible heat in flue gas; \btu\per\pound}
  * @endsymtable
  *
@@ -127,7 +127,7 @@
  * @par Symbols
  * @symtable
  * @symrow{p_{H_2O}; Partial pressure (mole fraction) of water vapor; \unitless}
- * @symrow{m_{i}; Mass of constituent i; \pound\per\pound\;fuel}
+ * @symrow{m_{i}; Mass of constituent i; \pound\per\poundFuel}
  * @symrow{0.047636; H2O specific weight - see @ref gas_constants; \pound\per\cubicFoot}
  * @symrow{0.116367; CO2 specific weight - see @ref gas_constants; \pound\per\cubicFoot}
  * @symrow{0.074077; N2 specific weight - see @ref gas_constants; \pound\per\cubicFoot}
@@ -141,8 +141,8 @@
  * in ash, and sensible heat carried away by hot ash.
  *
  * @formula{slfgm-h-moisture; h_{moisture} = X_{moisture} \cdot (T_{fg} - T_{ref})}
- * @formula{slfgm-h-carbon; h_{carbon} = 14093.0 \cdot X_{unburned,carbon} \cdot (X_{ash}/x_{fuel})}
- * @formula{slfgm-h-ash; h_{ash} = (X_{ash}/x_{fuel}) \cdot 0.25 \cdot (1.8 \cdot T_{ash,discharge} + 32.0 - T_{ref})}
+* @formula{slfgm-h-carbon; h_{carbon} = 14093.0 \cdot X_{unburned,carbon} \cdot \left(\frac{X_{ash}}{x_{fuel}}\right)}
+* @formula{slfgm-h-ash; h_{ash} = \left(\frac{X_{ash}}{x_{fuel}}\right) \cdot 0.25 \cdot (1.8 \cdot T_{ash,discharge} + 32.0 - T_{ref})}
  *
  * @par Symbols
  * @symtable
@@ -177,7 +177,7 @@
  *
  * @par Symbols
  * @symtable
- * @symrow{m_{i}; Mass of constituent i per unit fuel; \pound\per\pound\;fuel}
+ * @symrow{m_{i}; Mass of constituent i per unit fuel; \pound\per\poundFuel}
  * @symrow{x_C; Carbon mass fraction in fuel; \unitless}
  * @symrow{x_H; Hydrogen mass fraction in fuel; \unitless}
  * @symrow{x_S; Sulfur mass fraction in fuel; \unitless}
@@ -185,10 +185,10 @@
  * @symrow{k_{C\to CO_2}; Carbon to CO2 stoichiometric ratio - see @ref gas_constants; \pound\per\pound}
  * @symrow{k_{H\to H_2O}; Hydrogen to H2O stoichiometric ratio - see @ref gas_constants; \pound\per\pound}
  * @symrow{k_{S\to SO_2}; Sulfur to SO2 stoichiometric ratio - see @ref gas_constants; \pound\per\pound}
- * @symrow{M_{comb,air}; Total combustion air; \pound\per\pound\;fuel}
+ * @symrow{M_{comb,air}; Total combustion air; \pound\per\poundFuel}
  * @symrow{M_{air,moisture}; Moisture percent in combustion air; \percent}
- * @symrow{O2_{s,air}; Stoichiometric O2 required; \pound\per\pound\;fuel}
- * @symrow{N2_{s,air}; Stoichiometric N2 from air; \pound\per\pound\;fuel}
+ * @symrow{O2_{s,air}; Stoichiometric O2 required; \pound\per\poundFuel}
+ * @symrow{N2_{s,air}; Stoichiometric N2 from air; \pound\per\poundFuel}
  * @symrow{EA; Excess air fraction; \unitless}
  * @symrow{HV_{fuel}; Heating value of fuel; \btu\per\pound}
  * @symrow{k_{HV,C}; Heating value of carbon; \btu\per\pound}
@@ -210,10 +210,10 @@
  *
  * @par Symbols
  * @symtable
- * @symrow{O2_{s,air}; Stoichiometric O2 required; \pound\per\pound\;fuel}
- * @symrow{N2_{s,air}; Stoichiometric N2 from air; \pound\per\pound\;fuel}
- * @symrow{M_{s,air}; Stoichiometric air; \pound\per\pound\;fuel}
- * @symrow{M_{comb,air}; Total combustion air; \pound\per\pound\;fuel}
+ * @symrow{O2_{s,air}; Stoichiometric O2 required; \pound\per\poundFuel}
+ * @symrow{N2_{s,air}; Stoichiometric N2 from air; \pound\per\poundFuel}
+ * @symrow{M_{s,air}; Stoichiometric air; \pound\per\poundFuel}
+ * @symrow{M_{comb,air}; Total combustion air; \pound\per\poundFuel}
  * @symrow{x_C; Carbon mass fraction in fuel; \unitless}
  * @symrow{x_H; Hydrogen mass fraction in fuel; \unitless}
  * @symrow{x_S; Sulfur mass fraction in fuel; \unitless}
@@ -246,7 +246,7 @@
  * @symrow{b; Temperature coefficient for air specific heat; \btu\per\pound\degreeFahrenheit\squared}
  * @symrow{T_{comb}; Combustion air temperature; \degreeFahrenheit}
  * @symrow{h_{comb,air}; Sensible enthalpy of combustion air; \btu\per\pound}
- * @symrow{M_{comb,air}; Mass of combustion air; \pound\per\pound\;fuel}
+ * @symrow{M_{comb,air}; Mass of combustion air; \pound\per\poundFuel}
  * @symrow{\rho_{air}; Density of air; \pound\per\cubicFoot}
  * @endsymtable
  *


### PR DESCRIPTION
connects #63 
This pull request standardizes unit notation in the process heat loss calculator documentation and updates the MathJax configuration to support new units. The main focus is on replacing inconsistent uses of `\pound\per\pound\;fuel` with the newly defined `\pound\per\poundFuel` unit, and adding new MathJax SI unit definitions for clarity and consistency.

**Documentation consistency and clarity:**

* Updated all occurrences of `\pound\per\pound\;fuel` to use the new `\pound\per\poundFuel` notation throughout the process heat loss calculator documentation for consistent unit representation. [[1]](diffhunk://#diff-087bed75627679d5cbd12d682beee845eff10bfa76f6808331b5678e1bbd987eL93-R100) [[2]](diffhunk://#diff-087bed75627679d5cbd12d682beee845eff10bfa76f6808331b5678e1bbd987eL130-R130) [[3]](diffhunk://#diff-087bed75627679d5cbd12d682beee845eff10bfa76f6808331b5678e1bbd987eL180-R191) [[4]](diffhunk://#diff-087bed75627679d5cbd12d682beee845eff10bfa76f6808331b5678e1bbd987eL213-R216) [[5]](diffhunk://#diff-087bed75627679d5cbd12d682beee845eff10bfa76f6808331b5678e1bbd987eL249-R249)
* Improved formula formatting for clarity by wrapping fractions in `\left(\frac{...}{...}\right)` in relevant equations.

**MathJax configuration updates:**

* Added `\poundFuel` and `\inchMercury` as custom SI units in the MathJax configuration to support the new and existing unit notations in documentation. [[1]](diffhunk://#diff-f99f5af97a6b3b0f884c724a185bd3ab1e254f40248571ad6517a35160ab05f5R51) [[2]](diffhunk://#diff-f99f5af97a6b3b0f884c724a185bd3ab1e254f40248571ad6517a35160ab05f5R99)