### PR TITLE
fixup: process heating docs cleanup

### DIFF
--- a/docs/dox-content/calculators/processHeat/o2_enrichment_calculator.dox
+++ b/docs/dox-content/calculators/processHeat/o2_enrichment_calculator.dox
@@ -48,13 +48,8 @@
 /**
  * @defgroup o2_enrichment_excess_air_formula Excess Air Formula
  * @ingroup o2_enrichment_calculator
- * @brief Excess air calculated from oxygen concentration in flue gas.
- * @details The excess air is determined from the oxygen concentration in the flue gas using stoichiometric 
- * relationships. This calculation uses the shared @ref process_heat::calculateExcessAir function from the 
- * @ref process_heat namespace, which provides a consistent implementation across all process heat calculators.
  *
- * The formula uses empirical factors derived from combustion stoichiometry for typical fuels to account for 
- * the fact that excess oxygen in flue gas indicates incomplete combustion air utilization.
+ * @copydoc process_heat_excess_air_formula_doc
  *
  * @par Implementation
  * See @ref process_heat_excess_air_formula for the complete formula, symbol definitions, and implementation details.

--- a/docs/dox-content/calculators/processHeat/process_heat_calculator.dox
+++ b/docs/dox-content/calculators/processHeat/process_heat_calculator.dox
@@ -26,6 +26,15 @@
  * - O2 enrichment analysis (@ref o2_enrichment_calculator)
  * - Solid/liquid flue gas material calculations (@ref solid_liquid_flue_gas_material_calculator)
  *
+ * @copydoc process_heat_excess_air_formula_doc
+ *
+ * @note Input oxygen should be provided as a fraction (not percentage). For example, 3% O2 should be passed as 0.03.
+ */
+
+
+/**
+ * @defgroup process_heat_excess_air_formula_doc
+ *
  * The formula provides a quick estimate of excess air based on measured flue gas oxygen content. For more 
  * complex fuel compositions, iterative refinement may be applied (as in 
  * @ref solid_liquid_flue_gas_material::calculateExcessAirFromFlueGasO2).
@@ -40,11 +49,4 @@
  * @symrow{k_2; Oxygen flue gas factor (9.52381); \unitless}
  * @endsymtable
  *
- * @subheading{Implementation}
- * The function is implemented in the @ref process_heat namespace:
- * @code{.cpp}
- * double excess_air = process_heat::calculateExcessAir(o2_flue_gas_fraction);
- * @endcode
- *
- * @note Input oxygen should be provided as a fraction (not percentage). For example, 3% O2 should be passed as 0.03.
- */
+*/

--- a/include/processHeat/cascade_heat_high_to_low.h
+++ b/include/processHeat/cascade_heat_high_to_low.h
@@ -2,9 +2,8 @@
 #pragma once
 
 /**
- * @ingroup process_heat
+ * @ingroup cascade_heat_high_to_low_calculator
  * @file cascade_heat_high_to_low.h
- * @authors Omer Aziz (omerb)
  * @brief Functions to calculate energy savings from using exhaust gas (waste) of high temperature to supply heat to low temperature equipment.
  * @details Provides a function-based API for cascade heat recovery calculations.
  * @bug No known bugs.
@@ -14,14 +13,14 @@
 #include "losses/gas_flue_gas_material.h"
 
 /**
- * @ingroup process_heat
+ * @ingroup cascade_heat_high_to_low_calculator
  * @namespace cascade_heat_high_to_low
  * @brief Cascade heat recovery calculations for process heating systems.
  */
 namespace cascade_heat_high_to_low {
 
 /**
- * @ingroup process_heat
+ * @ingroup cascade_heat_high_to_low_calculator
  * @struct CascadeHeatHighToLowResults
  * @brief Results of the cascade heat high-to-low calculation.
  * @details Contains all output values from the cascade heat recovery calculation.
@@ -41,6 +40,7 @@ struct CascadeHeatHighToLowResults {
 };
 
 /**
+ * @ingroup cascade_heat_high_to_low_calculator
  * @brief Calculates the energy and cost savings from cascading heat from a high-temperature to a low-temperature process.
  * @details Uses flue gas properties and process parameters to estimate the benefit of using waste heat from a primary (high-temp) process to supply heat to a secondary (low-temp) process.
  *

--- a/include/processHeat/process_heat.h
+++ b/include/processHeat/process_heat.h
@@ -11,6 +11,7 @@
 namespace process_heat {
 
 /**
+ * @ingroup process_heat
  * @brief Calculates excess air from O2 in flue gas.
  * @param[in] o2_flue_gas O2 in flue gas (fraction)
  * @return Excess air (fraction)


### PR DESCRIPTION
connects #243 #238 

This pull request primarily improves the documentation for the process heat calculators, with a focus on clarifying the excess air calculation from O2 in flue gas and enhancing Doxygen grouping and references. It also makes minor corrections to group annotations in the cascade heat recovery calculator header.

**Documentation improvements:**

* Introduced a shared documentation group `process_heat_excess_air_formula_doc` with a detailed explanation of the excess air calculation formula, and used `@copydoc` to reference this documentation in both the O2 enrichment calculator and the main process heat calculator documentation, reducing duplication and ensuring consistency. [[1]](diffhunk://#diff-0b1ca154db8b3b8751c73bb51e12580e34f30733e559a4842f28114ab5dc0ce1R29-R37) [[2]](diffhunk://#diff-73e1551c02b351f58988b65a10525b4ef20777a228baa9ac03c6792f285f46ecL51-R52)
* Added a note in the documentation to clarify that O2 input should be provided as a fraction (e.g., 0.03 for 3%), improving usability and reducing potential confusion. [[1]](diffhunk://#diff-0b1ca154db8b3b8751c73bb51e12580e34f30733e559a4842f28114ab5dc0ce1R29-R37) [[2]](diffhunk://#diff-0b1ca154db8b3b8751c73bb51e12580e34f30733e559a4842f28114ab5dc0ce1L43-L49)
* Removed redundant implementation notes and code examples from the excess air formula documentation, consolidating information in the shared documentation group.

**Doxygen group corrections:**

* Updated `@ingroup` annotations in `cascade_heat_high_to_low.h` from `process_heat` to `cascade_heat_high_to_low_calculator` for the file, namespace, struct, and function, ensuring correct grouping in generated documentation. [[1]](diffhunk://#diff-b3b4ab7e3ea9ce867f1de807bb84909109e65795d61de6a5014ddb9c2f617d67L5-L7) [[2]](diffhunk://#diff-b3b4ab7e3ea9ce867f1de807bb84909109e65795d61de6a5014ddb9c2f617d67L17-R23) [[3]](diffhunk://#diff-b3b4ab7e3ea9ce867f1de807bb84909109e65795d61de6a5014ddb9c2f617d67R43)
* Added missing `@ingroup process_heat` annotation to the excess air calculation function in `process_heat.h` for improved documentation structure.