### PR TITLE
chore: address review feedback

### DIFF
--- a/docs/dox-content/calculators/treasureHunt/insulated_pipe_reduction_calculator.dox
+++ b/docs/dox-content/calculators/treasureHunt/insulated_pipe_reduction_calculator.dox
@@ -4,7 +4,8 @@
  * @brief Calculates heat loss per unit length and annual heat loss from a hot pipe,
  *        with or without thermal insulation.
  * @details This calculator estimates how much heat a hot pipe loses to the surrounding
- * air per unit length and over a full operating year. Two cases are supported:
+ * air or how much heat infiltrates a cold pipe from the surrounding air, per unit length
+ * and over a full operating year. Two cases are supported:
  * - **Insulated pipe** — the pipe is wrapped in an insulation layer of known thickness;
  *   heat must conduct through the pipe wall and the insulation before being dissipated
  *   to the air by convection and radiation at the jacket outer surface.
@@ -32,7 +33,7 @@
  * 7. Check convergence on heat loss per unit length; if converged, return the average
  *    of the previous and current values.
  *
- * Annual heat loss is obtained by multiplying the converged per-length value by pipe
+ * Annual heat loss or gain is obtained by multiplying the converged per-length value by pipe
  * length, annual operating hours, and the reciprocal of system efficiency.
  *
  * Relevant formulas and symbol definitions are documented below.

--- a/docs/dox-content/calculators/treasureHunt/insulated_tank_reduction_calculator.dox
+++ b/docs/dox-content/calculators/treasureHunt/insulated_tank_reduction_calculator.dox
@@ -3,9 +3,9 @@
  * @ingroup treasure_hunt_calculators
  * @brief Calculates heat loss and annual energy cost for a hot cylindrical tank,
  *        with or without thermal insulation.
- * @details This calculator estimates how much heat a hot vertical cylindrical tank
- * loses to the surrounding air and the equivalent annual energy that must be
- * supplied to the heating system to compensate for those losses. Two cases are
+ * @details This calculator estimates how much heat a hot or cold vertical cylindrical tank
+ * exchanges with the surrounding air and the equivalent annual energy that must be
+ * supplied to the heating or cooling systems to compensate for those losses. Two cases are
  * supported:
  * - **Insulated tank** — the tank wall is wrapped in a layer of insulation; heat
  *   conducts through the tank wall and the insulation annulus before being
@@ -22,7 +22,7 @@
  *    and specific heat) at the ambient temperature using fourth-order polynomial
  *    fits to tabulated data.
  * 2. Compute the thermal diffusivity of air from the polynomial-fitted properties.
- * 3. Compute the Rayleigh number from the outer surface temperature (jacket or bare
+ * 3. Compute the Rayleigh number (Ra) from the outer surface temperature (jacket or bare
  *    tank wall), the ambient temperature, and the air properties.
  * 4. Derive the natural convection heat transfer coefficient at the outer surface
  *    using the Ra^(1/3) empirical correlation.
@@ -139,7 +139,7 @@
  *
  * @subheading{Symbols}
  * @symtable
- * @symrow{h_{nat}; Natural convection heat transfer coefficient; \btu\per\hour\foot\squared\degreeFahrenheit}
+ * @symrow{h_{nat}; Natural convection heat transfer coefficient; \btu\per\hour\foot\squared\degreeRankine}
  * @symrow{\mathrm{Ra}; Rayleigh number; \unitless}
  * @symrow{k; Thermal conductivity of air at ambient temperature; \btu\per\hour\foot\degreeFahrenheit}
  * @symrow{d; Tank outer diameter; \foot}
@@ -216,12 +216,12 @@
  * result is scaled by 10⁻⁵ to produce the output unit.
  *
  * @formula{insulated-tank-conv-cond;
- *   q_{cc} = \frac{U \cdot A \cdot \Delta T}{10^5}
+ *   q_{cc} = U \cdot A \cdot \Delta T
  * }
  *
  * @subheading{Symbols}
  * @symtable
- * @symrow{q_{cc}; Convective–conductive heat loss (÷10⁵); \btu\per\hour}
+ * @symrow{q_{cc}; Convective–conductive heat loss; \btu\per\hour}
  * @symrow{U; Overall heat transfer coefficient (@math{U_{ins}} or @math{U_{bare}}); \btu\per\hour\foot\squared\degreeFahrenheit}
  * @symrow{A; Lateral tank surface area (@math{\pi\,d\,H}); \foot\squared}
  * @symrow{\Delta T; Temperature difference (surface – ambient); \degreeRankine}
@@ -236,12 +236,13 @@
  * constant and the emissivity of the outermost surface (jacket or bare tank wall).
  *
  * @formula{insulated-tank-radiation;
- *   q_{rad} = \frac{\sigma\,\varepsilon\,(T_s^4 - T_\infty^4)}{10^5}
+ *   q_{rad} = \sigma\,\varepsilon\,A\,(T_s^4 - T_\infty^4)
  * }
  *
  * @subheading{Symbols}
  * @symtable
- * @symrow{q_{rad}; Radiative heat loss (÷10⁵); \btu\per\hour\foot\squared}
+ * @symrow{q_{rad}; Radiative heat loss; \btu\per\hour}
+ * @symrow{A; Lateral tank surface area (@math{\pi\,d\,H}); \foot\squared}
  * @symrow{\sigma; Stefan–Boltzmann constant (1.713441 × 10⁻⁹); \btu\per\hour\foot\squared\degreeRankine\tothe{4}}
  * @symrow{\varepsilon; Surface emissivity (jacket or bare tank); \unitless}
  * @symrow{T_s; Outer surface temperature (jacket or bare tank wall); \degreeRankine}
@@ -258,13 +259,13 @@
  * to the annual energy equivalent the heating system must supply.
  *
  * @formula{insulated-tank-annual;
- *   Q_{annual} = \frac{q_{total} \cdot t_{op}}{10 \cdot \eta}
+ *   Q_{annual} = \frac{q_{total} \cdot t_{op}}{\eta}
  * }
  *
  * @subheading{Symbols}
  * @symtable
- * @symrow{Q_{annual}; Annual heat loss (÷10⁶, efficiency-adjusted); \btu}
- * @symrow{q_{total}; Total instantaneous heat loss (@math{q_{cc} + q_{rad}}, ÷10⁵); \btu\per\hour}
+ * @symrow{Q_{annual}; Annual heat loss (efficiency-adjusted); \btu}
+ * @symrow{q_{total}; Total instantaneous heat loss (@math{q_{cc} + q_{rad}}); \btu\per\hour}
  * @symrow{t_{op}; Annual operating hours; \hour\per\year}
  * @symrow{\eta; Heating system efficiency (0–1); \unitless}
  * @endsymtable


### PR DESCRIPTION
connects #131 

This pull request updates the documentation for the insulated pipe and tank heat loss calculators to clarify that both heat loss (from hot systems) and heat gain (into cold systems) are supported, and corrects several formulas, units, and symbol definitions for improved accuracy and clarity.

**Documentation and Concept Clarifications:**

* Updated descriptions in `insulated_pipe_reduction_calculator.dox` and `insulated_tank_reduction_calculator.dox` to clarify that the calculators handle both heat loss (hot systems) and heat gain (cold systems), as well as the corresponding annual energy calculations. [[1]](diffhunk://#diff-7b93044351e1c4ea00ed97375ebb285dd50fb06859d21cf0b4d17e826b61a40aL7-R8) [[2]](diffhunk://#diff-7b93044351e1c4ea00ed97375ebb285dd50fb06859d21cf0b4d17e826b61a40aL35-R36) [[3]](diffhunk://#diff-9369ed99cf5d6bfe3cc1d02f9a5a0821546bc639f6c3e6489b46c411a874f139L6-R8)

**Formula and Unit Corrections in Tank Calculator:**

* Corrected the formulas for convective–conductive (`q_{cc}`) and radiative (`q_{rad}`) heat loss in `insulated_tank_reduction_calculator.dox` by removing unnecessary scaling factors and updating the associated units and symbol definitions. [[1]](diffhunk://#diff-9369ed99cf5d6bfe3cc1d02f9a5a0821546bc639f6c3e6489b46c411a874f139L219-R224) [[2]](diffhunk://#diff-9369ed99cf5d6bfe3cc1d02f9a5a0821546bc639f6c3e6489b46c411a874f139L239-R245)
* Updated the annual heat loss formula (`Q_{annual}`) to remove a spurious scaling factor and clarified the associated symbol definitions.

**Technical and Notational Improvements:**

* Clarified the definition of the Rayleigh number (`Ra`) and improved the notation for the natural convection heat transfer coefficient (`h_{nat}`) to use the correct temperature unit (\degreeRankine). [[1]](diffhunk://#diff-9369ed99cf5d6bfe3cc1d02f9a5a0821546bc639f6c3e6489b46c411a874f139L25-R25) [[2]](diffhunk://#diff-9369ed99cf5d6bfe3cc1d02f9a5a0821546bc639f6c3e6489b46c411a874f139L142-R142)