### PR TITLE
fix(types): correct registered WASM vector declerations

### DIFF
--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup valgrind
         if: inputs.release_channel == 'beta'
         run: |
-          sudo apt-get install -y valgrind
+          sudo apt-get install -y --fix-missing valgrind
           valgrind --version
 
       - name: Set package version

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Setup valgrind
         if: inputs.release_channel == 'beta'
         run: |
-          sudo apt-get install -y --fix-missing valgrind
+          sudo apt-get update
+          sudo apt-get install -y libc6-dbg valgrind
           valgrind --version
 
       - name: Set package version

--- a/tests/wasm-mocha/processCooling/wasm_chiller_staging.test.ts
+++ b/tests/wasm-mocha/processCooling/wasm_chiller_staging.test.ts
@@ -1,0 +1,61 @@
+import { assert } from 'chai';
+import createModule, {
+    type DoubleVector,
+    type MeasurToolsSuite,
+    type StagingPowerConsumptionOutput,
+} from 'measur-tools-suite';
+
+describe('Chiller Staging Efficiency', function () {
+    let moduleInstance: MeasurToolsSuite;
+
+    before(async function () {
+        moduleInstance = await createModule({
+            locateFile: (filename: string) => '/base/bin/' + filename
+        });
+    });
+
+    function createDoubleVector(values: number[]): DoubleVector {
+        const vector: DoubleVector = new moduleInstance.DoubleVector();
+        values.forEach((value: number) => vector.push_back(value));
+        return vector;
+    }
+
+    it('accepts and returns registered double vectors', function () {
+        const baselineLoads: DoubleVector = createDoubleVector([300, 300, 300]);
+        const modificationLoads: DoubleVector = createDoubleVector([450, 450, 0]);
+        let output: StagingPowerConsumptionOutput | undefined;
+        let baselinePower: DoubleVector | undefined;
+        let modificationPower: DoubleVector | undefined;
+
+        try {
+            output = moduleInstance.ChillerStagingEfficiency(
+                moduleInstance.ChillerType.Centrifugal,
+                moduleInstance.CondenserCoolingType.Water,
+                moduleInstance.CompressorConfigType.VFD,
+                1000,
+                0.676,
+                1,
+                1,
+                42,
+                82.12,
+                baselineLoads,
+                modificationLoads
+            );
+
+            baselinePower = output.baselinePowerList;
+            modificationPower = output.modPowerList;
+
+            assert.equal(baselinePower.size(), 3);
+            assert.equal(modificationPower.size(), 3);
+            assert.approximately(baselinePower.get(0), 273.5006, 0.001);
+            assert.approximately(modificationPower.get(0), 301.9545, 0.001);
+            assert.approximately(output.savingsEnergy, 216.5928, 0.001);
+        } finally {
+            baselinePower?.delete();
+            modificationPower?.delete();
+            output?.delete();
+            baselineLoads.delete();
+            modificationLoads.delete();
+        }
+    });
+});

--- a/tests/wasm-mocha/steam/steamModeler/wasm_header.test.ts
+++ b/tests/wasm-mocha/steam/steamModeler/wasm_header.test.ts
@@ -1,0 +1,63 @@
+import { assert } from 'chai';
+import createModule, {
+    type Header,
+    type Inlet,
+    type InletVector,
+    type MeasurToolsSuite,
+    type SteamPropertiesOutput,
+} from 'measur-tools-suite';
+
+describe('Steam Header', function () {
+    let moduleInstance: MeasurToolsSuite;
+
+    before(async function () {
+        moduleInstance = await createModule({
+            locateFile: (filename: string) => '/base/bin/' + filename
+        });
+    });
+
+    it('constructs and returns registered inlet vectors', function () {
+        const inletVector: InletVector = new moduleInstance.InletVector();
+        let header: Header | undefined;
+        let headerProperties: SteamPropertiesOutput | undefined;
+        let returnedInlets: InletVector | undefined;
+
+        const inletInputs: Array<[number, number, number, number]> = [
+            [1.9332, moduleInstance.ThermodynamicQuantity.TEMPERATURE, 579.8, 0.686],
+            [2.8682, moduleInstance.ThermodynamicQuantity.TEMPERATURE, 308.5, 0.5019],
+            [1.0348, moduleInstance.ThermodynamicQuantity.TEMPERATURE, 458, 0.5633],
+            [1.8438, moduleInstance.ThermodynamicQuantity.TEMPERATURE, 475.8, 0.3082],
+        ];
+
+        try {
+            for (const [pressure, quantityType, quantityValue, massFlow] of inletInputs) {
+                const inlet: Inlet = new moduleInstance.Inlet(pressure, quantityType, quantityValue, massFlow);
+                try {
+                    inletVector.push_back(inlet);
+                } finally {
+                    inlet.delete();
+                }
+            }
+
+            header = new moduleInstance.Header(0.173, inletVector);
+            headerProperties = header.getHeaderProperties();
+            returnedInlets = header.getInlets();
+
+            assert.approximately(headerProperties.pressure, 0.173, 0.001);
+            assert.approximately(header.getInletMassFlow(), 2.0594, 0.001);
+            assert.equal(returnedInlets.size(), 4);
+
+            const firstInlet: Inlet = returnedInlets.get(0);
+            try {
+                assert.approximately(firstInlet.getMassFlow(), 0.686, 0.001);
+            } finally {
+                firstInlet.delete();
+            }
+        } finally {
+            returnedInlets?.delete();
+            headerProperties?.delete();
+            header?.delete();
+            inletVector.delete();
+        }
+    });
+});

--- a/tests/wasm-mocha/wasteWater/wasm_waste_water_treatment.test.ts
+++ b/tests/wasm-mocha/wasteWater/wasm_waste_water_treatment.test.ts
@@ -1,0 +1,50 @@
+import { assert } from 'chai';
+import createModule, {
+    type CalculationsTable,
+    type CalculationsTableV,
+    type DoubleVector,
+    type MeasurToolsSuite,
+    type WasteWater_Treatment,
+    type WasteWater_TreatmentOutput,
+} from 'measur-tools-suite';
+
+describe('Wastewater Treatment', function () {
+    let moduleInstance: MeasurToolsSuite;
+
+    before(async function () {
+        moduleInstance = await createModule({
+            locateFile: (filename: string) => '/base/bin/' + filename
+        });
+    });
+
+    it('returns calculation rows as registered double vectors', function () {
+        const treatment: WasteWater_Treatment = new moduleInstance.WasteWater_Treatment(
+            20, 200, 1, 1, 40, 35, 0.85, 200, 20, 8,
+            10000, 3000, 0.1, 0.6, 60, 0.1, 8, 72, 2, 4.5,
+            0.84, 0.92, 2.7, 150, 200, 24, 1, 100, 0.09, 1
+        );
+        let output: WasteWater_TreatmentOutput | undefined;
+        let calculationsTable: CalculationsTableV | undefined;
+        let calculationRow: CalculationsTable | undefined;
+        let rowValues: DoubleVector | undefined;
+
+        try {
+            output = treatment.calculate();
+            calculationsTable = output.calculationsTable;
+            calculationRow = calculationsTable.get(0);
+            rowValues = calculationRow.getArray();
+
+            assert.approximately(output.SolidsRetentionTime, 29, 0.01);
+            assert.isAbove(calculationsTable.size(), 0);
+            assert.equal(rowValues.size(), 26);
+            assert.approximately(rowValues.get(0), calculationRow.Se, 0.0001);
+            assert.approximately(rowValues.get(25), calculationRow.SRT, 0.0001);
+        } finally {
+            rowValues?.delete();
+            calculationRow?.delete();
+            calculationsTable?.delete();
+            output?.delete();
+            treatment.delete();
+        }
+    });
+});

--- a/ts_def/ts_def_modules/processCooling/chillers.d.ts
+++ b/ts_def/ts_def_modules/processCooling/chillers.d.ts
@@ -4,6 +4,8 @@
  * Chiller Efficiency (Temperature Reset Capacity, Staging).
  */
 
+import type { DoubleVector } from '../binding/registered_vectors';
+
 // ---------------------------------------------------------------------------
 // Enumerations
 // ---------------------------------------------------------------------------
@@ -103,10 +105,16 @@ export interface PowerEnergyConsumptionOutput {
  * @property savingsEnergy double, units kWh
  */
 export interface StagingPowerConsumptionOutput {
-    /** Power consumption for each baseline chiller load, units kW */
-    baselinePowerList: number[];
-    /** Power consumption for each modification chiller load, units kW */
-    modPowerList: number[];
+    /**
+     * Registered WASM vector of baseline chiller power values, units kW.
+     * Call `delete()` when finished.
+     */
+    baselinePowerList: DoubleVector;
+    /**
+     * Registered WASM vector of modification chiller power values, units kW.
+     * Call `delete()` when finished.
+     */
+    modPowerList: DoubleVector;
     /** Total baseline power, units kW */
     baselineTotalPower: number;
     /** Total baseline energy, units kWh */
@@ -328,8 +336,8 @@ export function ChillerCapacityEfficiency(
  * @param operatingHours double, operating hours, units hours
  * @param waterSupplyTemp double, chilled water supply temperature, units F
  * @param waterEnteringTemp double, condenser water entering temperature, units F
- * @param baselineLoadList list of doubles for each baseline chiller load, units ton
- * @param modLoadList list of doubles for each modification chiller load, units ton
+ * @param baselineLoadList Registered WASM vector of baseline chiller loads, units ton
+ * @param modLoadList Registered WASM vector of modification chiller loads, units ton
  * @returns {@link StagingPowerConsumptionOutput}
  */
 export function ChillerStagingEfficiency(
@@ -342,8 +350,8 @@ export function ChillerStagingEfficiency(
     operatingHours: number,
     waterSupplyTemp: number,
     waterEnteringTemp: number,
-    baselineLoadList: number[],
-    modLoadList: number[]
+    baselineLoadList: DoubleVector,
+    modLoadList: DoubleVector
 ): StagingPowerConsumptionOutput;
 
 export type ChillersModule = {

--- a/ts_def/ts_def_modules/steamModeler/ssmt.d.ts
+++ b/ts_def/ts_def_modules/steamModeler/ssmt.d.ts
@@ -14,6 +14,7 @@ import type {
     Solve,
     TurbineProperty,
 } from './ssmtEnum';
+import type { InletVector } from '../binding/registered_vectors';
 
 export type { ThermodynamicQuantity, Solve, TurbineProperty };
 
@@ -564,9 +565,10 @@ export declare class Inlet {
 export declare class Header {
     /**
      * @param headerPressure Header pressure, units MPa
-     * @param inletVec Array of {@link Inlet} objects
+     * @param inletVec Registered WASM vector of {@link Inlet} objects. Call
+     * `delete()` when finished with the vector.
      */
-    constructor(headerPressure: number, inletVec: Inlet[]);
+    constructor(headerPressure: number, inletVec: InletVector);
 
     /** @returns {@link SteamPropertiesOutput} combined header steam properties */
     getHeaderProperties(): SteamPropertiesOutput;
@@ -576,8 +578,11 @@ export declare class Header {
     getInletEnergyFlow(): number;
     /** @returns Total inlet mass flow, units kg/hr */
     getInletMassFlow(): number;
-    /** @returns Array of {@link Inlet} objects */
-    getInlets(): Inlet[];
+    /**
+     * @returns Registered WASM vector of {@link Inlet} objects. Call `delete()`
+     * when finished with the vector.
+     */
+    getInlets(): InletVector;
 
     /** Frees the underlying resource; must be called when finished with the instance */
     delete(): void;

--- a/ts_def/ts_def_modules/wasteWater/wasteWater.d.ts
+++ b/ts_def/ts_def_modules/wasteWater/wasteWater.d.ts
@@ -5,7 +5,7 @@
  * process outputs with and without the full iteration calculations table.
  */
 
-import { CalculationsTableV } from "../binding/registered_vectors";
+import type { CalculationsTableV, DoubleVector } from "../binding/registered_vectors";
 
 /**
  * Iteration row of intermediate wastewater-treatment calculations.
@@ -67,8 +67,11 @@ export declare class CalculationsTable {
     /** Solids retention time, units days. */
     SRT: number;
 
-    /** @returns Numeric array view of this row in model-defined order */
-    getArray(): number[];
+    /**
+     * @returns Registered WASM vector of row values in model-defined order.
+     * Call `delete()` when finished.
+     */
+    getArray(): DoubleVector;
 
     /** Frees the underlying resource; must be called when finished with the instance */
     delete(): void;


### PR DESCRIPTION
https://github.com/ORNL-AMO/AMO-Tools-Desktop/issues/8766

This pull request adds new integration tests for several modules in the `measur-tools-suite` WebAssembly bindings. The tests verify that the modules correctly construct and return registered vectors and output objects, ensuring that the data passed between JavaScript and WASM is handled as expected.

**New WASM Integration Tests:**

*Chiller Staging Efficiency:*
- Adds a test for `ChillerStagingEfficiency` to verify it accepts and returns registered `DoubleVector` objects, and checks the correctness of calculated power and energy savings values.

*Steam Header Modeling:*
- Introduces a test for the `Header` and `InletVector` classes, ensuring that inlet vectors are constructed, returned, and their properties validated, including mass flow and pressure.

*Wastewater Treatment Calculations:*
- Implements a test for `WasteWater_Treatment` to ensure it returns calculation tables as registered double vectors, and validates the calculation results and table structure.