### PR TITLE
Updates for v1.2.4 Release

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = MEASUR-Tools-Suite
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = v1.2.3
+PROJECT_NUMBER         = v1.2.4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/steam/steam_leak_survey.h
+++ b/include/steam/steam_leak_survey.h
@@ -231,7 +231,7 @@ public:
         const double energyLoss = leakEnthalpy * steamLoss / 1000;
 
         const double leakCost = steamLoss * costOfSteam(turbineEfficiency) * 1000 *
-            (leakEnthalpy - feedwaterEnthalpy) / (steamSpecificEnthalpy - feedwaterEnthalpy);
+            (turbineEfficiency != 0 ? (leakEnthalpy - feedwaterEnthalpy) / (steamSpecificEnthalpy - feedwaterEnthalpy) : 1);
 
         return {leakRate, steamLoss, energyLoss, leakCost};
     }

--- a/include/steam/steam_leak_survey.h
+++ b/include/steam/steam_leak_survey.h
@@ -202,7 +202,7 @@ public:
      * leakCost MMBtu/lb-MCF
      */
     SteamLeakSurveyResults plumeMethodCalc(const double turbineEfficiency, const double plumeLength, const double ambTemp) const {
-        const double leakRate = QuantifySteamLeakByPlumeLength::estimate(steamPressure, plumeLength, ambTemp);    // lb/hr
+        const double leakRate = QuantifySteamLeakByPlumeLength::estimate(leakPressure, plumeLength, ambTemp);    // lb/hr
 
         return calculate(leakRate, turbineEfficiency);
     }

--- a/include/steam/steam_leak_survey.h
+++ b/include/steam/steam_leak_survey.h
@@ -121,7 +121,7 @@ public:
         const auto feedwaterTempK = physics::conversions::fahrenheitToKelvin(feedwaterTemp);
 
         const auto steamProperties = SteamProperties(steamPressureMPa, SteamProperties::ThermodynamicQuantity::TEMPERATURE, steamTempK).calculate();
-        specificHeatRatio = steamProperties.isentropicExponent;
+        specificHeatRatio = steamProperties.specificIsobaricHeatCapacity_cp / steamProperties.specificIsochoricHeatCapacity_cv;
         steamSpecificEnthalpy = steamProperties.specificEnthalpy;
         isentropicEnthalpy = SteamProperties(leakPressureMPa, SteamProperties::ThermodynamicQuantity::ENTROPY,steamProperties.specificEntropy).calculate().specificEnthalpy;
         leakEnthalpy = SteamProperties(leakPressureMPa, SteamProperties::ThermodynamicQuantity::TEMPERATURE,leakTempK).calculate().specificEnthalpy;

--- a/include/steam/steam_leak_survey.h
+++ b/include/steam/steam_leak_survey.h
@@ -121,7 +121,7 @@ public:
         const auto feedwaterTempK = physics::conversions::fahrenheitToKelvin(feedwaterTemp);
 
         const auto steamProperties = SteamProperties(steamPressureMPa, SteamProperties::ThermodynamicQuantity::TEMPERATURE, steamTempK).calculate();
-        specificHeatRatio = steamProperties.specificIsobaricHeatCapacity_cp / steamProperties.specificIsochoricHeatCapacity_cv;
+        specificHeatRatio = steamProperties.isentropicExponent;
         steamSpecificEnthalpy = steamProperties.specificEnthalpy;
         isentropicEnthalpy = SteamProperties(leakPressureMPa, SteamProperties::ThermodynamicQuantity::ENTROPY,steamProperties.specificEntropy).calculate().specificEnthalpy;
         leakEnthalpy = SteamProperties(leakPressureMPa, SteamProperties::ThermodynamicQuantity::TEMPERATURE,leakTempK).calculate().specificEnthalpy;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "measur-tools-suite",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "measur-tools-suite",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "^5.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "measur-tools-suite",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "engines": {
     "node": "20.19.4",
     "npm": "10.8.2"

--- a/tests/cpp/steam/steam_leak_survey.unit.cpp
+++ b/tests/cpp/steam/steam_leak_survey.unit.cpp
@@ -28,7 +28,7 @@ TEST_CASE("Steam Leak of a boiler system:", "[steamLeakSurvey]") {
     const auto steamLeak = SteamLeakSurvey(8760, 500, 300, 0.1, 200, 400, 70, 80, 75, 15.50, 1.038);
     INFO("Estimate Method (PRV): ");
     validateSteamLeaks(steamLeak.estimateMethodPRVCalc(500),
-             {500, 4380, 5291.35,  137405.72});
+             {500, 4380, 5291.35,  143049.55});
     INFO("Passed");
 
     INFO("Estimate Method (Backpressure Turbine): ");

--- a/tests/cpp/steam/steam_leak_survey.unit.cpp
+++ b/tests/cpp/steam/steam_leak_survey.unit.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Steam Leak of a boiler system:", "[steamLeakSurvey]") {
 
     INFO("Orifice Method: ");
     validateSteamLeaks(steamLeak.orificeMethodCalc(90, 0.25, 0.8748, 14.70),
-             {482.71, 4228.58, 5108.42, 128823.25});
+             {497.93, 4361.83, 5269.39, 132882.69});
     INFO("Passed");
 
     INFO("Plume Method: ");

--- a/tests/cpp/steam/steam_leak_survey.unit.cpp
+++ b/tests/cpp/steam/steam_leak_survey.unit.cpp
@@ -43,6 +43,6 @@ TEST_CASE("Steam Leak of a boiler system:", "[steamLeakSurvey]") {
 
     INFO("Plume Method: ");
     validateSteamLeaks(steamLeak.plumeMethodCalc(90, 8, 80),
-             {447.426, 3919.45, 4734.97, 119405.69});
+             {427.796, 3747.496, 4527.236, 114167.08});
     INFO("Passed");
 }

--- a/tests/cpp/steam/steam_leak_survey.unit.cpp
+++ b/tests/cpp/steam/steam_leak_survey.unit.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Steam Leak of a boiler system:", "[steamLeakSurvey]") {
 
     INFO("Orifice Method: ");
     validateSteamLeaks(steamLeak.orificeMethodCalc(90, 0.25, 0.8748, 14.70),
-             {497.93, 4361.83, 5269.39, 132882.69});
+             {482.71, 4228.58, 5108.42, 128823.25});
     INFO("Passed");
 
     INFO("Plume Method: ");

--- a/tests/wasm-mocha/steam/wasm_steam_leak_survey.test.ts
+++ b/tests/wasm-mocha/steam/wasm_steam_leak_survey.test.ts
@@ -49,7 +49,7 @@ describe('Steam Leak Survey', function () {
                 {leakRate: 500, steamLoss: 4380, energyLoss: 5291.35, leakCost: 133436.27});
 
             validateSteamLeakResults(steamLeak.orificeMethodCalc(90, 0.25, 0.8748, 14.70),
-                {leakRate: 482.71, steamLoss: 4228.58, energyLoss: 5108.42, leakCost: 128823.25});
+                {leakRate: 497.93, steamLoss: 4361.83, energyLoss: 5269.39, leakCost: 132882.69});
 
             validateSteamLeakResults(steamLeak.plumeMethodCalc(90, 8, 80),
                 {leakRate: 447.426, steamLoss: 3919.45, energyLoss: 4734.97, leakCost: 119405.69});

--- a/tests/wasm-mocha/steam/wasm_steam_leak_survey.test.ts
+++ b/tests/wasm-mocha/steam/wasm_steam_leak_survey.test.ts
@@ -43,7 +43,7 @@ describe('Steam Leak Survey', function () {
         const steamLeak = new moduleInstance.SteamLeakSurvey(8760, 500, 300, 0.1, 200, 400, 70, 80, 75, 15.50, 1.038);
         try {
             validateSteamLeakResults(steamLeak.estimateMethodPRVCalc(500),
-                {leakRate: 500, steamLoss: 4380, energyLoss: 5291.35, leakCost: 137405.72});
+                {leakRate: 500, steamLoss: 4380, energyLoss: 5291.35, leakCost: 143049.55});
 
             validateSteamLeakResults(steamLeak.estimateMethodTurbineCalc(90, 500),
                 {leakRate: 500, steamLoss: 4380, energyLoss: 5291.35, leakCost: 133436.27});

--- a/tests/wasm-mocha/steam/wasm_steam_leak_survey.test.ts
+++ b/tests/wasm-mocha/steam/wasm_steam_leak_survey.test.ts
@@ -49,7 +49,7 @@ describe('Steam Leak Survey', function () {
                 {leakRate: 500, steamLoss: 4380, energyLoss: 5291.35, leakCost: 133436.27});
 
             validateSteamLeakResults(steamLeak.orificeMethodCalc(90, 0.25, 0.8748, 14.70),
-                {leakRate: 497.93, steamLoss: 4361.83, energyLoss: 5269.39, leakCost: 132882.69});
+                {leakRate: 482.71, steamLoss: 4228.58, energyLoss: 5108.42, leakCost: 128823.25});
 
             validateSteamLeakResults(steamLeak.plumeMethodCalc(90, 8, 80),
                 {leakRate: 447.426, steamLoss: 3919.45, energyLoss: 4734.97, leakCost: 119405.69});

--- a/tests/wasm-mocha/steam/wasm_steam_leak_survey.test.ts
+++ b/tests/wasm-mocha/steam/wasm_steam_leak_survey.test.ts
@@ -52,7 +52,7 @@ describe('Steam Leak Survey', function () {
                 {leakRate: 482.71, steamLoss: 4228.58, energyLoss: 5108.42, leakCost: 128823.25});
 
             validateSteamLeakResults(steamLeak.plumeMethodCalc(90, 8, 80),
-                {leakRate: 447.426, steamLoss: 3919.45, energyLoss: 4734.97, leakCost: 119405.69});
+                {leakRate: 427.796, steamLoss: 3747.496, energyLoss: 4527.236, leakCost: 114167.08});
         } finally {
             steamLeak.delete();
         }


### PR DESCRIPTION
This pull request updates the version to `v1.2.4` and makes several corrections and improvements to the steam leak survey calculations. The main changes focus on fixing a parameter in the plume method calculation, improving cost calculation logic, and updating test cases to reflect these corrections.

**Steam Leak Survey Calculation Fixes and Improvements:**

* Changed the parameter from `steamPressure` to `leakPressure` in the `plumeMethodCalc` method of `SteamLeakSurvey`, ensuring the correct pressure is used in leak rate estimation.
* Improved the leak cost calculation formula to handle cases where `turbineEfficiency` is zero, preventing division by zero and returning a default value.

**Test Case Updates:**

* Updated expected results in C++ unit tests (`steam_leak_survey.unit.cpp`) to match the corrected plume method and cost calculations. [[1]](diffhunk://#diff-62d2a767283920fa63938bd624453139592fb3fca8fd25a6cfe6d4e2fffa293aL31-R31) [[2]](diffhunk://#diff-62d2a767283920fa63938bd624453139592fb3fca8fd25a6cfe6d4e2fffa293aL46-R46)
* Updated expected results in WASM/TypeScript tests (`wasm_steam_leak_survey.test.ts`) for both PRV and plume methods to reflect the calculation changes. [[1]](diffhunk://#diff-414f35f2ddf9fb7611e3d3188edfff828b260895520c134714737da244206d9dL46-R46) [[2]](diffhunk://#diff-414f35f2ddf9fb7611e3d3188edfff828b260895520c134714737da244206d9dL55-R55)

**Versioning:**

* Bumped project version from `1.2.3` to `1.2.4` in both `Doxyfile` and `package.json` to reflect these changes. [[1]](diffhunk://#diff-ad99e4a448d7bc3792ea4acfb4c5a9048e2d604b1e9a9613fc39a2dbb53c48a9L51-R51) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)